### PR TITLE
[Feat] 회원 수정(Update), 삭제(Delete) RestAPI 개발 및 지역구별 혜택 조회 기능 개발

### DIFF
--- a/src/main/java/sandbox/apricot/auth/config/MemberAuthExceptionEntryPoint.java
+++ b/src/main/java/sandbox/apricot/auth/config/MemberAuthExceptionEntryPoint.java
@@ -16,7 +16,7 @@ public class MemberAuthExceptionEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
-        String errorMessage = "{\"error\": \"아이디 또는 비밀번호가 맞지 않습니다.\"}";
+        String errorMessage = "{\"exception\": \"" + authException.getMessage() + "\"}";
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(SC_UNAUTHORIZED);
         response.getWriter().write(errorMessage);

--- a/src/main/java/sandbox/apricot/auth/config/MemberAuthExceptionEntryPoint.java
+++ b/src/main/java/sandbox/apricot/auth/config/MemberAuthExceptionEntryPoint.java
@@ -1,27 +1,43 @@
 package sandbox.apricot.auth.config;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+@Log4j2
 @Component
 public class MemberAuthExceptionEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
-        String errorMessage = "{\"exception\": \"" + authException.getMessage() + "\"}";
-        response.setContentType("application/json; charset=UTF-8");
-        response.setStatus(SC_UNAUTHORIZED);
-        response.getWriter().write(errorMessage);
-        response.getWriter().flush();
-        response.getWriter().close();
+        // 인증되지 않은 상태에서 접근 시 예외 처리
+        String errorMessage = "인증이 필요합니다.";
+
+        // 로그 출력
+        log.error(">>> [ ❌ 인증 실패 ]");
+
+        // 응답 데이터를 JSON 형식으로 설정
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 에러 메시지 생성
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("code", HttpStatus.UNAUTHORIZED.value());
+        responseBody.put("message", errorMessage);
+
+        // JSON으로 응답
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
     }
 
 }

--- a/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
+++ b/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
@@ -25,7 +26,7 @@ public class MemberAuthFailureHandler implements AuthenticationFailureHandler {
         log.error(">>> [ ❌ 로그인 실패: {} ]", exception.getMessage());  // 예외 메시지 로그 출력
         String errorMessage = "알 수 없는 에러가 발생하여 로그인에 실패 하였습니다.";
 
-        if (exception instanceof BadCredentialsException) {
+        if (exception instanceof UsernameNotFoundException || exception instanceof BadCredentialsException) {
             errorMessage = exception.getMessage();
         }
 

--- a/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
+++ b/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
@@ -1,29 +1,42 @@
 package sandbox.apricot.auth.config;
 
-import static jakarta.servlet.http.HttpServletResponse.*;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-/**
- * 로그인 실패시 에러 메시지를 띄우기 위한 핸들러
- */
+@Log4j2
 @Component
-public class MemberAuthFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+public class MemberAuthFailureHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException, ServletException {
-        String errorMessage = "{\"fail\": \"" + exception.getMessage() + "\"}";
-        response.setStatus(SC_UNAUTHORIZED);
-        response.setContentType("application/json; charset=UTF-8");
-        response.getWriter().write(errorMessage);
-        response.getWriter().flush();
-        response.getWriter().close();
+        log.error(">>> [ ❌ 로그인 실패: {} ]", exception.getMessage());  // 예외 메시지 로그 출력
+        String errorMessage = "알 수 없는 에러가 발생하여 로그인에 실패 하였습니다.";
+
+        if (exception instanceof BadCredentialsException) {
+            errorMessage = exception.getMessage();
+        }
+
+        response.setStatus(UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("code", UNAUTHORIZED.value());
+        responseBody.put("message", errorMessage);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
     }
 }

--- a/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
+++ b/src/main/java/sandbox/apricot/auth/config/MemberAuthFailureHandler.java
@@ -19,7 +19,7 @@ public class MemberAuthFailureHandler extends SimpleUrlAuthenticationFailureHand
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
             AuthenticationException exception) throws IOException, ServletException {
-        String errorMessage = "{\"error\": \"아이디 또는 비밀번호가 맞지 않습니다.\"}";
+        String errorMessage = "{\"fail\": \"" + exception.getMessage() + "\"}";
         response.setStatus(SC_UNAUTHORIZED);
         response.setContentType("application/json; charset=UTF-8");
         response.getWriter().write(errorMessage);

--- a/src/main/java/sandbox/apricot/auth/config/SecurityConfig.java
+++ b/src/main/java/sandbox/apricot/auth/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -23,8 +24,9 @@ import sandbox.apricot.auth.provider.MemberAuthenticatorProvider;
 
 @Log4j2
 @Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final MemberAuthenticatorProvider memberAuthenticatorProvider;

--- a/src/main/java/sandbox/apricot/auth/config/SecurityConfig.java
+++ b/src/main/java/sandbox/apricot/auth/config/SecurityConfig.java
@@ -61,30 +61,34 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> {
-                    auth.requestMatchers("/", "/register", "/register-interest", "/mypage",
-                                    "/resume/**", "/policy/**").permitAll()
-                            .requestMatchers("/api/v1/**").permitAll()
-                            .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
-                            .dispatcherTypeMatchers(DispatcherType.INCLUDE).permitAll()
-                            .anyRequest().authenticated();
-                })
-                .formLogin(form -> {
-                    form.loginPage("/login")
-                            .loginProcessingUrl("/api/v1/login")
-                            .defaultSuccessUrl("/")
-                            .failureHandler(failureHandler)
-                            .permitAll();
-                })
-                .exceptionHandling(handler -> {
-                    handler.authenticationEntryPoint(entryPoint);
-                })
-                .logout(exit -> {
-                    exit.logoutUrl("/api/v1/logout")
-                            .logoutSuccessUrl("/")
-                            .deleteCookies("JSESSIONID")
-                            .invalidateHttpSession(true);
-                });
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/", "/resume/**",
+                                "/register", "/register-interest",
+                                "/mypage",
+                                "/policy/**"
+                        ).permitAll()
+                        .requestMatchers("/api/v1/**").permitAll()
+                        .dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+                        .dispatcherTypeMatchers(DispatcherType.INCLUDE).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .loginPage("/login")
+                        .loginProcessingUrl("/api/v1/login")
+                        .defaultSuccessUrl("/")
+                        .failureHandler(failureHandler)
+                        .permitAll()
+                )
+                .logout(exit -> exit
+                        .logoutUrl("/api/v1/logout")
+                        .logoutSuccessUrl("/")
+                        .deleteCookies("JSESSIONID")
+                        .invalidateHttpSession(true)
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(entryPoint)
+                );
         return http.build();
     }
 

--- a/src/main/java/sandbox/apricot/auth/provider/MemberAuthenticatorProvider.java
+++ b/src/main/java/sandbox/apricot/auth/provider/MemberAuthenticatorProvider.java
@@ -1,5 +1,7 @@
 package sandbox.apricot.auth.provider;
 
+import static sandbox.apricot.member.util.exception.MemberErrorCode.*;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -12,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import sandbox.apricot.auth.dto.MemberPrincipalDetails;
 import sandbox.apricot.auth.service.MemberPrincipalDetailService;
+import sandbox.apricot.member.util.exception.MemberBusinessException;
 
 @Log4j2
 @Component
@@ -32,8 +35,9 @@ public class MemberAuthenticatorProvider implements AuthenticationProvider {
         log.info(">>> [ 🔍 데이터베이스에 등록된 사용자 계정을 확인 합니다. ]");
 
         if (!passwordEncoder.matches(password, dbPassword)) {
-            throw new BadCredentialsException(">>> [ ❌ 사용자의 아이디 혹은 비밀번호가 일치하지 않습니다.");
+            throw new BadCredentialsException("아이디 또는 비밀번호가 일치하지 않습니다.");
         }
+
         log.info(">>> [ ✅ 사용자 인증이 완료 되었습니다. ]");
         return new UsernamePasswordAuthenticationToken(memberPrincipalDetails, null, memberPrincipalDetails.getAuthorities());
     }

--- a/src/main/java/sandbox/apricot/auth/service/MemberPrincipalDetailService.java
+++ b/src/main/java/sandbox/apricot/auth/service/MemberPrincipalDetailService.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import sandbox.apricot.auth.dto.MemberPrincipalDetails;
-import sandbox.apricot.member.util.exception.MemberBusinessException;
 import sandbox.apricot.member.mapper.MemberMapper;
 
 @Service
@@ -21,7 +20,7 @@ public class MemberPrincipalDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return new MemberPrincipalDetails(
                 memberMapper.findByEmail(username)
-                        .orElseThrow(() -> new MemberBusinessException(MEMBER_NOT_FOUND))
+                        .orElseThrow(() -> new UsernameNotFoundException("아이디 또는 비밀번호가 일치하지 않습니다."))
         );
     }
 

--- a/src/main/java/sandbox/apricot/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sandbox/apricot/common/exception/GlobalExceptionHandler.java
@@ -9,9 +9,9 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.annotation.Order;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import sandbox.apricot.common.response.ApiResponse;
@@ -32,17 +32,10 @@ public class GlobalExceptionHandler {
      * MethodArgumentNotValidException과는 다르게 Bean Validation API를 직접 다룰 때 발생합니다.
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    protected ResponseEntity<ApiResponse> handleConstraintViolationException (
-            ConstraintViolationException exception
-    ) {
-        return ResponseEntity
-                .status(BAD_REQUEST)
-                .body(
-                        ApiResponse.errorResponse(
-                                BAD_REQUEST,
-                                exception.getMessage()
-                        )
-                );
+    @ResponseStatus(BAD_REQUEST)
+    protected ApiResponse<Void> handleConstraintViolationException(
+            ConstraintViolationException exception) {
+        return ApiResponse.errorResponse(BAD_REQUEST, exception.getMessage());
     }
 
     /**
@@ -50,39 +43,25 @@ public class GlobalExceptionHandler {
      * 메시지의 경우 유효성 검사 결과 객체에서 필드 오류 정보를 찾은 후, 해당 예외의 기본 메시지를 추출하여 문자열로 반환합니다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException exception
-    ) {
+    @ResponseStatus(BAD_REQUEST)
+    protected ApiResponse<Void> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception) {
         log.error(" >>> [ ❌ MethodArgumentNotValidException: {} ]", exception.getMessage());
         String errorMessages = exception.getBindingResult().getFieldErrors()
                 .stream()
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .toList().toString();
-
-        return ResponseEntity
-                .status(BAD_REQUEST)
-                .body(ApiResponse.errorResponse(
-                        BAD_REQUEST,
-                        errorMessages
-                ));
+        return ApiResponse.errorResponse(BAD_REQUEST, errorMessages);
     }
 
     /**
      * 서버에서 요청한 리소스를 찾을 수 없는 예외를 핸들링하는 메서드입니다.
      */
     @ExceptionHandler(NoHandlerFoundException.class)
-    protected ResponseEntity<ApiResponse> handleNotFoundException (
-            NoHandlerFoundException exception
-    ) {
+    @ResponseStatus(NOT_FOUND)
+    protected ApiResponse<Void> handleNotFoundException(NoHandlerFoundException exception) {
         log.error(" >>> [ ❌ NoHandlerFoundException: {} ]", exception.getMessage());
-        return ResponseEntity
-                .status(NOT_FOUND)
-                .body(
-                        ApiResponse.errorResponse(
-                                NOT_FOUND,
-                                exception.getMessage()
-                        )
-                );
+        return ApiResponse.errorResponse(NOT_FOUND, exception.getMessage());
     }
 
     /**
@@ -90,20 +69,11 @@ public class GlobalExceptionHandler {
      * 어떤 문제인지 파악하기 쉽도록 request의 일부와 exception 스택 트레이스 로그를 출력합니다.
      */
     @ExceptionHandler({Exception.class})
-    protected ResponseEntity<ApiResponse> handleException (
-            Exception exception,
-            HttpServletRequest request
-    ) {
-        log.error(" >>> [ ❌ 서버 내부에서 문제가 발생했습니다. method: {}, requestURI: {}, msg: {}, exception: {} ]", request.getMethod(), request.getRequestURI(), exception.getMessage(), exception);
-        log.error("{}", (Object) exception.getStackTrace());
-        return ResponseEntity
-                .status(INTERNAL_SERVER_ERROR)
-                .body(
-                        ApiResponse.errorResponse(
-                                INTERNAL_SERVER_ERROR,
-                                exception.getMessage()
-                        )
-                );
+    @ResponseStatus(INTERNAL_SERVER_ERROR)
+    protected ApiResponse<Void> handleException(Exception exception, HttpServletRequest request) {
+        log.error(" >>> [ ❌ 서버 내부에서 문제가 발생했습니다. method: {}, requestURI: {}, exception: {} ]",
+                request.getMethod(), request.getRequestURI(), exception);
+        return ApiResponse.errorResponse(INTERNAL_SERVER_ERROR, exception.getMessage());
     }
 
 }

--- a/src/main/java/sandbox/apricot/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sandbox/apricot/common/exception/GlobalExceptionHandler.java
@@ -1,48 +1,109 @@
 package sandbox.apricot.common.exception;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
+import org.springframework.core.annotation.Order;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.NoHandlerFoundException;
 import sandbox.apricot.common.response.ApiResponse;
 
+/**
+ * GlobalExceptionHandler: 도메인과 관련된 예외가 아닌 나머지 예외를 핸들링하는 클래스입니다.
+ * 기본적인 예외를 처리하기 위해 ResponseEntityExceptionHandler를 상속 받습니다.
+ * 400(유효성 검사), 404, 500 에러에 대한 예외를 핸들링합니다.
+ * 가장 낮은 우선순위로 예외를 핸들링합니다.
+ */
+@Order
 @Log4j2
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * 유효성 검사를 수행하여 실패했을 경우 발생하는 ConstraintViolationException 예외를 핸들링하는 메서드입니다.
+     * MethodArgumentNotValidException과는 다르게 Bean Validation API를 직접 다룰 때 발생합니다.
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse> handleConstraintViolationException (
+            ConstraintViolationException exception
+    ) {
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(
+                        ApiResponse.errorResponse(
+                                BAD_REQUEST,
+                                exception.getMessage()
+                        )
+                );
+    }
+
+    /**
+     * 유효성 검사를 진행할 @Valid 어노테이션이 붙은 요청 DTO 클래스에서 유효성 검사가 실패할 경우 발생하는 예외를 핸들링하는 메서드입니다.
+     * 메시지의 경우 유효성 검사 결과 객체에서 필드 오류 정보를 찾은 후, 해당 예외의 기본 메시지를 추출하여 문자열로 반환합니다.
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<String>> handleValidationExceptions(
-            MethodArgumentNotValidException ex, WebRequest request) {
+    protected ResponseEntity<ApiResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception
+    ) {
+        log.error(" >>> [ ❌ MethodArgumentNotValidException: {} ]", exception.getMessage());
+        String errorMessages = exception.getBindingResult().getFieldErrors()
+                .stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .toList().toString();
 
-        Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult().getAllErrors().forEach((error) -> {
-            if (error instanceof FieldError) {
-                String fieldName = ((FieldError) error).getField();
-                String errorMessage = error.getDefaultMessage();
-                errors.put(fieldName, errorMessage);
-            }
-        });
+        return ResponseEntity
+                .status(BAD_REQUEST)
+                .body(ApiResponse.errorResponse(
+                        BAD_REQUEST,
+                        errorMessages
+                ));
+    }
 
-        String errorMessages = errors.entrySet().stream()
-                .map(entry -> String.format("Field: %s, Error: %s", entry.getKey(), entry.getValue()))
-                .collect(Collectors.joining(", "));
-        log.warn("Validation errors: [{}]", errorMessages);
+    /**
+     * 서버에서 요청한 리소스를 찾을 수 없는 예외를 핸들링하는 메서드입니다.
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    protected ResponseEntity<ApiResponse> handleNotFoundException (
+            NoHandlerFoundException exception
+    ) {
+        log.error(" >>> [ ❌ NoHandlerFoundException: {} ]", exception.getMessage());
+        return ResponseEntity
+                .status(NOT_FOUND)
+                .body(
+                        ApiResponse.errorResponse(
+                                NOT_FOUND,
+                                exception.getMessage()
+                        )
+                );
+    }
 
-        String combinedErrorMessage = String.join("; ", errors.values());
-
-        ApiResponse<String> response = ApiResponse.errorResponse(
-                HttpStatus.BAD_REQUEST,
-                combinedErrorMessage
-        );
-
-        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    /**
+     * 서버 내부에서 문제 발생시 예외를 핸들링하는 메서드입니다.
+     * 어떤 문제인지 파악하기 쉽도록 request의 일부와 exception 스택 트레이스 로그를 출력합니다.
+     */
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<ApiResponse> handleException (
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        log.error(" >>> [ ❌ 서버 내부에서 문제가 발생했습니다. method: {}, requestURI: {}, msg: {}, exception: {} ]", request.getMethod(), request.getRequestURI(), exception.getMessage(), exception);
+        log.error("{}", (Object) exception.getStackTrace());
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR)
+                .body(
+                        ApiResponse.errorResponse(
+                                INTERNAL_SERVER_ERROR,
+                                exception.getMessage()
+                        )
+                );
     }
 
 }

--- a/src/main/java/sandbox/apricot/interest/controller/InterestRestController.java
+++ b/src/main/java/sandbox/apricot/interest/controller/InterestRestController.java
@@ -1,0 +1,46 @@
+package sandbox.apricot.interest.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import java.security.Principal;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sandbox.apricot.common.response.ApiResponse;
+import sandbox.apricot.interest.dto.request.InterestRegister;
+import sandbox.apricot.interest.service.InterestService;
+import sandbox.apricot.member.service.MemberService;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/interest")
+public class InterestRestController {
+
+    private final InterestService interestService;
+    private final MemberService memberService;
+
+    /**
+     * 관심사 수정
+     *
+     * @param request - List<String> categoryInfo;
+     */
+    @PutMapping("/update")
+    public ResponseEntity<ApiResponse<Void>> updateInterest(
+            @RequestBody List<String> request, Principal principal) {
+        Long memberId = memberService.getMemberId(principal.getName());
+        interestService.update(InterestRegister.of(memberId, request));
+        return ResponseEntity.ok().body(
+                ApiResponse.successResponse(
+                        OK,
+                        "성공적으로 관심사 정보를 수정하였습니다."
+                )
+        );
+    }
+
+}

--- a/src/main/java/sandbox/apricot/interest/controller/InterestRestController.java
+++ b/src/main/java/sandbox/apricot/interest/controller/InterestRestController.java
@@ -6,10 +6,10 @@ import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.apricot.common.response.ApiResponse;
 import sandbox.apricot.interest.dto.request.InterestRegister;
@@ -19,6 +19,7 @@ import sandbox.apricot.member.service.MemberService;
 @RestController
 @Log4j2
 @RequiredArgsConstructor
+@ResponseStatus(OK)
 @RequestMapping("/api/v1/interest")
 public class InterestRestController {
 
@@ -31,16 +32,11 @@ public class InterestRestController {
      * @param request - List<String> categoryInfo;
      */
     @PutMapping("/update")
-    public ResponseEntity<ApiResponse<Void>> updateInterest(
-            @RequestBody List<String> request, Principal principal) {
+    public ApiResponse<Void> updateInterest(@RequestBody List<String> request,
+            Principal principal) {
         Long memberId = memberService.getMemberId(principal.getName());
         interestService.update(InterestRegister.of(memberId, request));
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 관심사 정보를 수정하였습니다."
-                )
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 관심사 정보를 수정하였습니다.");
     }
 
 }

--- a/src/main/java/sandbox/apricot/interest/mapper/InterestMapper.java
+++ b/src/main/java/sandbox/apricot/interest/mapper/InterestMapper.java
@@ -8,6 +8,9 @@ import sandbox.apricot.interest.vo.Interest;
 public interface InterestMapper {
 
     void save(Interest interest);
+
     List<Interest> findByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 
 }

--- a/src/main/java/sandbox/apricot/interest/service/InterestService.java
+++ b/src/main/java/sandbox/apricot/interest/service/InterestService.java
@@ -6,4 +6,6 @@ public interface InterestService {
 
     void register(InterestRegister request);
 
+    void update(InterestRegister request);
+
 }

--- a/src/main/java/sandbox/apricot/interest/service/InterestServiceImpl.java
+++ b/src/main/java/sandbox/apricot/interest/service/InterestServiceImpl.java
@@ -37,6 +37,12 @@ public class InterestServiceImpl implements InterestService {
         log.info(" >>> [ ✨ 회원 ID: {} 의 관심사 등록을 완료 하였습니다. ]", memberId);
     }
 
+    @Override
+    public void update(InterestRegister request) {
+        interestMapper.deleteByMemberId(request.getMemberId());
+        register(request);
+    }
+
     private void validateCategory(String categoryId) {
         if (categoryMapper.findById(categoryId).isEmpty()) {
             throw new InterestBusinessException(CATEGORY_NOT_FOUND);

--- a/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
+++ b/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -77,8 +79,7 @@ public class MemberRestController {
     @PreAuthorize("isAuthenticated()")
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> updateMember(
-            @RequestBody @Valid UpdatePassword request,
-            Principal principal) {
+            @RequestBody @Valid UpdatePassword request, Principal principal) {
         Long memberId = memberService.getMemberId(principal.getName());
         memberService.updatePassword(request, memberId);
         return ResponseEntity.ok().body(
@@ -95,7 +96,8 @@ public class MemberRestController {
      * @param request - memberId, nickName
      */
     @PatchMapping("/nickname")
-    public ResponseEntity<ApiResponse<Void>> updateMember(@RequestBody @Valid UpdateNickName request) {
+    public ResponseEntity<ApiResponse<Void>> updateMember(
+            @RequestBody @Valid UpdateNickName request) {
         memberService.updateNickName(request.toService());
         return ResponseEntity.ok().body(
                 ApiResponse.successResponse(
@@ -111,12 +113,29 @@ public class MemberRestController {
      * @param request - memberId, nickName
      */
     @PatchMapping("/ageRange")
-    public ResponseEntity<ApiResponse<Void>> updateMember(@RequestBody @Valid UpdateAgeRange request) {
+    public ResponseEntity<ApiResponse<Void>> updateMember(
+            @RequestBody @Valid UpdateAgeRange request) {
         memberService.updateAgeRange(request.toService());
         return ResponseEntity.ok().body(
                 ApiResponse.successResponse(
                         OK,
                         "성공적으로 회원 나이대 정보를 수정하였습니다."
+                )
+        );
+    }
+
+    /**
+     * 회원 삭제
+     */
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Void>> delete(Principal principal) {
+        Long memberId = memberService.getMemberId(principal.getName());
+        memberService.delete(memberId);
+        return ResponseEntity.ok().body(
+                ApiResponse.successResponse(
+                        OK,
+                        "성공적으로 회원을 삭제하였습니다."
                 )
         );
     }

--- a/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
+++ b/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
@@ -4,9 +4,11 @@ import static org.springframework.http.HttpStatus.*;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +19,7 @@ import sandbox.apricot.member.dto.request.MemberRegisterBasic;
 import sandbox.apricot.member.dto.request.MemberRegisterDetail;
 import sandbox.apricot.member.dto.request.UpdateAgeRange;
 import sandbox.apricot.member.dto.request.UpdateNickName;
+import sandbox.apricot.member.dto.request.UpdatePassword;
 import sandbox.apricot.member.service.MemberService;
 
 @RestController
@@ -62,6 +65,26 @@ public class MemberRestController {
                 ApiResponse.successResponse(
                         OK,
                         "성공적으로 회원가입을 완료하였습니다."
+                )
+        );
+    }
+
+    /**
+     * 회원 수정 - 비밀번호 변경
+     *
+     * @param request - oldPassword, newPassword
+     */
+    @PreAuthorize("isAuthenticated()")
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updateMember(
+            @RequestBody @Valid UpdatePassword request,
+            Principal principal) {
+        Long memberId = memberService.getMemberId(principal.getName());
+        memberService.updatePassword(request, memberId);
+        return ResponseEntity.ok().body(
+                ApiResponse.successResponse(
+                        OK,
+                        "성공적으로 회원 비밀번호를 수정하였습니다."
                 )
         );
     }

--- a/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
+++ b/src/main/java/sandbox/apricot/member/controller/MemberRestController.java
@@ -7,13 +7,13 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.apricot.common.response.ApiResponse;
 import sandbox.apricot.member.dto.request.MemberRegisterBasic;
@@ -30,6 +30,7 @@ import sandbox.apricot.member.service.MemberService;
 @RestController
 @Log4j2
 @RequiredArgsConstructor
+@ResponseStatus(OK)
 @RequestMapping("/api/v1/member")
 public class MemberRestController {
 
@@ -42,15 +43,11 @@ public class MemberRestController {
      * @param reqBasic - email, password, nickName
      */
     @PostMapping("/register-basic")
-    public ResponseEntity<ApiResponse<Void>> saveMember(
-            @RequestBody @Valid MemberRegisterBasic reqBasic
-    ) {
+    public ApiResponse<Void> saveMember(@RequestBody @Valid MemberRegisterBasic reqBasic) {
         session.setAttribute("reqBasic", reqBasic);
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "기본 정보가 세션에 저장 되었습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "기본 정보가 세션에 저장 되었습니다."
         );
     }
 
@@ -60,17 +57,15 @@ public class MemberRestController {
      * @param reqDetail - ageRange, gender, career, marriedStatus, numChild, interests
      */
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse<Void>> registerMember(
+    public ApiResponse<Void> registerMember(
             @RequestBody @Valid MemberRegisterDetail reqDetail
     ) {
         MemberRegisterBasic reqBasic = (MemberRegisterBasic) session.getAttribute("reqBasic");
         memberService.register(reqBasic.toService(), reqDetail.toService());
         session.removeAttribute("reqBasic"); // 기본 정보 삭제
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 회원가입을 완료하였습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 회원가입을 완료하였습니다."
         );
     }
 
@@ -81,15 +76,13 @@ public class MemberRestController {
      */
     @PreAuthorize("isAuthenticated()")
     @PatchMapping("/password")
-    public ResponseEntity<ApiResponse<Void>> updateMember(
+    public ApiResponse<Void> updateMember(
             @RequestBody @Valid UpdatePassword request, Principal principal) {
         Long memberId = memberService.getMemberId(principal.getName());
         memberService.updatePassword(request, memberId);
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 회원 비밀번호를 수정하였습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 회원 비밀번호를 수정하였습니다."
         );
     }
 
@@ -98,15 +91,13 @@ public class MemberRestController {
      *
      * @param request - memberId, nickName
      */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/nickname")
-    public ResponseEntity<ApiResponse<Void>> updateMember(
-            @RequestBody @Valid UpdateNickName request) {
+    public ApiResponse<Void> updateMember(@RequestBody @Valid UpdateNickName request) {
         memberService.updateNickName(request.toService());
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 회원 닉네임 정보를 수정하였습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 회원 닉네임 정보를 수정하였습니다."
         );
     }
 
@@ -115,32 +106,28 @@ public class MemberRestController {
      *
      * @param request - memberId, nickName
      */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/ageRange")
-    public ResponseEntity<ApiResponse<Void>> updateMember(
-            @RequestBody @Valid UpdateAgeRange request) {
+    public ApiResponse<Void> updateMember(@RequestBody @Valid UpdateAgeRange request) {
         memberService.updateAgeRange(request.toService());
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 회원 나이대 정보를 수정하였습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 회원 나이대 정보를 수정하였습니다."
         );
     }
 
     /**
-    * 회원 수정 - 직업 변경
-    *
-    * @param request - memberId , career
-    */
+     * 회원 수정 - 직업 변경
+     *
+     * @param request - memberId , career
+     */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/career")
-    public ResponseEntity<ApiResponse<Void>> updateCareer(
-            @RequestBody @Valid UpdateCareer request){
+    public ApiResponse<Void> updateCareer(@RequestBody @Valid UpdateCareer request) {
         memberService.updateCareer(request);
-        return ResponseEntity.ok().body(
-            ApiResponse.successResponse(
+        return ApiResponse.successResponse(
                 OK,
                 "성공적으로 직업을 수정하였습니다.."
-            )
         );
     }
 
@@ -149,15 +136,13 @@ public class MemberRestController {
      *
      * @param request - memberId , marriedStatus
      */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/marriedStatus")
-    public ResponseEntity<ApiResponse<Void>> updateMarriedStatus(
-            @RequestBody @Valid UpdateMarriedStatus request){
+    public ApiResponse<Void> updateMarriedStatus(@RequestBody @Valid UpdateMarriedStatus request) {
         memberService.updateMarriedStatus(request);
-        return ResponseEntity.ok().body(
-            ApiResponse.successResponse(
+        return ApiResponse.successResponse(
                 OK,
                 "성공적으로 결혼상태를 수정하였습니다."
-            )
         );
     }
 
@@ -166,15 +151,13 @@ public class MemberRestController {
      *
      * @param request - memberId , numChild
      */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/numChild")
-    public ResponseEntity<ApiResponse<Void>> updateNumChild(
-            @RequestBody @Valid UpdateNumChild request){
+    public ApiResponse<Void> updateNumChild(@RequestBody @Valid UpdateNumChild request) {
         memberService.updateNumChild(request);
-        return ResponseEntity.ok().body(
-            ApiResponse.successResponse(
+        return ApiResponse.successResponse(
                 OK,
                 "성공적으로 자녀수를 수정하였습니다."
-            )
         );
     }
 
@@ -183,15 +166,13 @@ public class MemberRestController {
      *
      * @param request - memberId , gender
      */
+    @PreAuthorize("isAuthenticated()")
     @PatchMapping("/gender")
-    public ResponseEntity<ApiResponse<Void>> updateGender(
-            @RequestBody @Valid UpdateGender request){
+    public ApiResponse<Void> updateGender(@RequestBody @Valid UpdateGender request) {
         memberService.updateGender(request);
-        return ResponseEntity.ok().body(
-            ApiResponse.successResponse(
+        return ApiResponse.successResponse(
                 OK,
                 "성공적으로 성별을 수정하였습니다."
-            )
         );
     }
 
@@ -200,15 +181,14 @@ public class MemberRestController {
      */
     @PreAuthorize("isAuthenticated()")
     @DeleteMapping
-    public ResponseEntity<ApiResponse<Void>> delete(Principal principal) {
+    public ApiResponse<Void> delete(Principal principal) {
         Long memberId = memberService.getMemberId(principal.getName());
         memberService.delete(memberId);
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 회원을 삭제하였습니다."
-                )
+        return ApiResponse.successResponse(
+                OK,
+                "성공적으로 회원을 삭제하였습니다."
         );
     }
 
 }
+

--- a/src/main/java/sandbox/apricot/member/dto/request/UpdatePassword.java
+++ b/src/main/java/sandbox/apricot/member/dto/request/UpdatePassword.java
@@ -1,0 +1,27 @@
+package sandbox.apricot.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import sandbox.apricot.member.util.annotation.Password;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class UpdatePassword {
+
+    @NotBlank
+    private final String oldPassword;
+
+    @Password
+    private final String newPassword;
+
+    public static UpdatePassword of(String oldPassword, String newPassword) {
+        return UpdatePassword.builder()
+                .oldPassword(oldPassword)
+                .newPassword(newPassword)
+                .build();
+    }
+
+}

--- a/src/main/java/sandbox/apricot/member/mapper/MemberMapper.java
+++ b/src/main/java/sandbox/apricot/member/mapper/MemberMapper.java
@@ -9,11 +9,18 @@ import sandbox.apricot.member.vo.Member;
 public interface MemberMapper {
 
     void save(Member member);
+
     Optional<Member> findById(Long memberId);
+
     Optional<Member> findByEmail(String email);
+
     Optional<Member> findByNickName(String nickName);
+
     MemberInfo findByIdWithInterests(Long memberId);
+
     void updateNickNameById(Long memberId, String nickName);
+
     void updateAgeRangeById(Long memberId, String ageRange);
 
+    void updatePassword(Long memberId, String password);
 }

--- a/src/main/java/sandbox/apricot/member/mapper/MemberMapper.java
+++ b/src/main/java/sandbox/apricot/member/mapper/MemberMapper.java
@@ -23,4 +23,7 @@ public interface MemberMapper {
     void updateAgeRangeById(Long memberId, String ageRange);
 
     void updatePassword(Long memberId, String password);
+
+    void deleteById(Long memberId);
+
 }

--- a/src/main/java/sandbox/apricot/member/service/MemberService.java
+++ b/src/main/java/sandbox/apricot/member/service/MemberService.java
@@ -4,14 +4,21 @@ import sandbox.apricot.member.dto.request.MemberRegisterBasic;
 import sandbox.apricot.member.dto.request.MemberRegisterDetail;
 import sandbox.apricot.member.dto.request.UpdateAgeRange;
 import sandbox.apricot.member.dto.request.UpdateNickName;
+import sandbox.apricot.member.dto.request.UpdatePassword;
 import sandbox.apricot.member.dto.response.MemberInfo;
 
 public interface MemberService {
 
     void register(MemberRegisterBasic reqBasic, MemberRegisterDetail reqDetail);
+
     Long getMemberId(String email);
+
     MemberInfo getMemberInfo(Long memberId);
+
     void updateNickName(UpdateNickName request);
+
     void updateAgeRange(UpdateAgeRange request);
+
+    void updatePassword(UpdatePassword request, Long memberId);
 
 }

--- a/src/main/java/sandbox/apricot/member/service/MemberService.java
+++ b/src/main/java/sandbox/apricot/member/service/MemberService.java
@@ -21,4 +21,6 @@ public interface MemberService {
 
     void updatePassword(UpdatePassword request, Long memberId);
 
+    void delete(Long memberId);
+
 }

--- a/src/main/java/sandbox/apricot/member/service/MemberServiceImpl.java
+++ b/src/main/java/sandbox/apricot/member/service/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import static sandbox.apricot.member.util.exception.MemberErrorCode.EMAIL_DUPLIC
 import static sandbox.apricot.member.util.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static sandbox.apricot.member.util.exception.MemberErrorCode.NICKNAME_DUPLICATE;
 import static sandbox.apricot.member.util.exception.MemberErrorCode.UNAUTHORIZED_TO_MEMBER;
+import static sandbox.apricot.member.util.exception.MemberErrorCode.WRONG_PASSWORD;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -71,7 +72,7 @@ public class MemberServiceImpl implements MemberService {
         String newPassword = request.getNewPassword();
         String curPassword = member.getPassword();
 
-        validateForbidden(oldPassword, curPassword);
+        validatePassword(oldPassword, curPassword);
         memberMapper.updatePassword(memberId, passwordEncoder.encode(newPassword));
     }
 
@@ -168,9 +169,9 @@ public class MemberServiceImpl implements MemberService {
         }
     }
 
-    private void validateForbidden(String oldPassword, String newPassword) {
+    private void validatePassword(String oldPassword, String newPassword) {
         if (!passwordEncoder.matches(oldPassword, newPassword)) {
-            throw new MemberBusinessException(UNAUTHORIZED_TO_MEMBER);
+            throw new MemberBusinessException(WRONG_PASSWORD);
         }
     }
 

--- a/src/main/java/sandbox/apricot/member/service/MemberServiceImpl.java
+++ b/src/main/java/sandbox/apricot/member/service/MemberServiceImpl.java
@@ -95,6 +95,13 @@ public class MemberServiceImpl implements MemberService {
         memberMapper.updatePassword(memberId, passwordEncoder.encode(newPassword));
     }
 
+    @Override
+    public void delete(Long memberId) {
+        log.info(" >>> [ ✨ 회원 삭제를 시도합니다. 회원 ID: {} ]", memberId);
+        memberMapper.deleteById(memberId);
+        log.info(" >>> [ ✨ 회원 삭제 성공. 회원 ID: {} ]", memberId);
+    }
+
     private void validateDuplicationEmail(String email) {
         if (memberMapper.findByEmail(email).isPresent()) {
             throw new MemberBusinessException(EMAIL_DUPLICATE);

--- a/src/main/java/sandbox/apricot/member/util/exception/MemberErrorCode.java
+++ b/src/main/java/sandbox/apricot/member/util/exception/MemberErrorCode.java
@@ -13,19 +13,19 @@ import sandbox.apricot.common.exception.ErrorCode;
 @Getter
 public enum MemberErrorCode implements ErrorCode {
 
-    MEMBER_NOT_FOUND(NOT_FOUND, ">>> [ ❌ 존재하지 않는 회원 입니다. ]"),
-    UNAUTHORIZED_TO_MEMBER(FORBIDDEN, ">>> [ ❌ 권한이 없는 회원 입니다. ]"),
+    MEMBER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원 입니다."),
+    UNAUTHORIZED_TO_MEMBER(FORBIDDEN, "권한이 없는 회원 입니다."),
 
-    WRONG_PASSWORD(BAD_REQUEST, ">>> [ ❌ 비밀번호를 다시 확인해 주세요. ]"),
-    PASSWORD_CONDITIONS_VIOLATION(BAD_REQUEST, ">>> [ ❌ 비밀번호는 8자 이상, 20자 이하이어야 하며, 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다. ]"),
+    WRONG_PASSWORD(BAD_REQUEST, "비밀번호를 다시 확인해 주세요."),
+    PASSWORD_CONDITIONS_VIOLATION(BAD_REQUEST, "비밀번호는 8자 이상, 20자 이하이어야 하며, 대문자, 소문자, 숫자, 특수 문자를 포함해야 합니다."),
 
-    EMAIL_DUPLICATE(BAD_REQUEST, ">>> [ ❌ 이미 사용 중인 이메일입니다. ]"),
-    INVALID_EMAIL_FORMAT(BAD_REQUEST, ">>> [ ❌ 유효하지 않은 이메일 형식입니다. ]"),
+    EMAIL_DUPLICATE(BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+    INVALID_EMAIL_FORMAT(BAD_REQUEST, "유효하지 않은 이메일 형식입니다."),
 
-    WRONG_NICKNAME(BAD_REQUEST, ">>> [ ❌ 닉네임을 다시 확인해 주세요. ]"),
-    NICKNAME_DUPLICATE(BAD_REQUEST, ">>> [ ❌ 이미 사용 중인 닉네임입니다. ]"),
-    NICKNAME_RANGE_VIOLATION(BAD_REQUEST, ">>> [ ❌ 닉네임은 2자 이상, 10자 미만이어야 합니다. ]"),
-    NICKNAME_CONTAINS_SPECIAL_CHAR(BAD_REQUEST, ">>> [ ❌ 닉네임에 특수문자를 포함할 수 없습니다. ]");
+    WRONG_NICKNAME(BAD_REQUEST, "닉네임을 다시 확인해 주세요."),
+    NICKNAME_DUPLICATE(BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+    NICKNAME_RANGE_VIOLATION(BAD_REQUEST, "닉네임은 2자 이상, 10자 미만이어야 합니다."),
+    NICKNAME_CONTAINS_SPECIAL_CHAR(BAD_REQUEST, "닉네임에 특수문자를 포함할 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sandbox/apricot/policy/controller/PolicyRestController.java
+++ b/src/main/java/sandbox/apricot/policy/controller/PolicyRestController.java
@@ -5,9 +5,9 @@ import static org.springframework.http.HttpStatus.OK;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.apricot.common.response.ApiResponse;
 import sandbox.apricot.policy.dto.response.DistrictPolicy;
@@ -16,21 +16,16 @@ import sandbox.apricot.policy.service.PolicyService;
 @RestController
 @Log4j2
 @RequiredArgsConstructor
+@ResponseStatus(OK)
 @RequestMapping("/api/v1/policy")
 public class PolicyRestController {
 
     private final PolicyService policyService;
 
     @GetMapping("/word-cloud")
-    public ResponseEntity<ApiResponse<List<DistrictPolicy>>> getDistrictPolicies() {
+    public ApiResponse<List<DistrictPolicy>> getDistrictPolicies() {
         List<DistrictPolicy> data = policyService.getPolicyCntByDistrict();
-        return ResponseEntity.ok().body(
-                ApiResponse.successResponse(
-                        OK,
-                        "성공적으로 지역구별 혜택수를 조회하였습니다.",
-                        data
-                )
-        );
+        return ApiResponse.successResponse(OK, "성공적으로 지역구별 혜택수를 조회하였습니다.", data);
     }
 
 }

--- a/src/main/java/sandbox/apricot/policy/controller/PolicyRestController.java
+++ b/src/main/java/sandbox/apricot/policy/controller/PolicyRestController.java
@@ -1,0 +1,36 @@
+package sandbox.apricot.policy.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sandbox.apricot.common.response.ApiResponse;
+import sandbox.apricot.policy.dto.response.DistrictPolicy;
+import sandbox.apricot.policy.service.PolicyService;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/policy")
+public class PolicyRestController {
+
+    private final PolicyService policyService;
+
+    @GetMapping("/word-cloud")
+    public ResponseEntity<ApiResponse<List<DistrictPolicy>>> getDistrictPolicies() {
+        List<DistrictPolicy> data = policyService.getPolicyCntByDistrict();
+        return ResponseEntity.ok().body(
+                ApiResponse.successResponse(
+                        OK,
+                        "성공적으로 지역구별 혜택수를 조회하였습니다.",
+                        data
+                )
+        );
+    }
+
+}

--- a/src/main/java/sandbox/apricot/policy/dto/response/DistrictPolicy.java
+++ b/src/main/java/sandbox/apricot/policy/dto/response/DistrictPolicy.java
@@ -1,0 +1,21 @@
+package sandbox.apricot.policy.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DistrictPolicy {
+
+    private String districtName;
+    private Integer policyCnt;
+
+    @Builder
+    public DistrictPolicy(String districtName, Integer policyCnt) {
+        this.districtName = districtName;
+        this.policyCnt = policyCnt;
+    }
+
+}

--- a/src/main/java/sandbox/apricot/policy/mapper/PolicyMapper.java
+++ b/src/main/java/sandbox/apricot/policy/mapper/PolicyMapper.java
@@ -1,0 +1,12 @@
+package sandbox.apricot.policy.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import sandbox.apricot.policy.dto.response.DistrictPolicy;
+
+@Mapper
+public interface PolicyMapper {
+
+    List<DistrictPolicy> getPolicyCountByDistrict();
+
+}

--- a/src/main/java/sandbox/apricot/policy/service/PolicyService.java
+++ b/src/main/java/sandbox/apricot/policy/service/PolicyService.java
@@ -1,0 +1,10 @@
+package sandbox.apricot.policy.service;
+
+import java.util.List;
+import sandbox.apricot.policy.dto.response.DistrictPolicy;
+
+public interface PolicyService {
+
+    List<DistrictPolicy> getPolicyCntByDistrict();
+
+}

--- a/src/main/java/sandbox/apricot/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/sandbox/apricot/policy/service/PolicyServiceImpl.java
@@ -1,0 +1,26 @@
+package sandbox.apricot.policy.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sandbox.apricot.policy.dto.response.DistrictPolicy;
+import sandbox.apricot.policy.mapper.PolicyMapper;
+
+@Log4j2
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PolicyServiceImpl implements PolicyService {
+
+    private final PolicyMapper policyMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DistrictPolicy> getPolicyCntByDistrict() {
+        log.info(" >>> [ ✨ 지역구 혜택 수를 조회 합니다. ]");
+        return policyMapper.getPolicyCountByDistrict();
+    }
+
+}

--- a/src/main/java/sandbox/apricot/scrap/controller/ScrapRestController.java
+++ b/src/main/java/sandbox/apricot/scrap/controller/ScrapRestController.java
@@ -4,33 +4,30 @@ import static org.springframework.http.HttpStatus.OK;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import sandbox.apricot.common.response.ApiResponse;
 import sandbox.apricot.scrap.dto.request.ScrapRegister;
 import sandbox.apricot.scrap.service.ScrapService;
 
 @RestController
-@Log4j2 // Log 사용을 위해 추가
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/scrap") // API Path 수정 [Before] >>> "api/scrap"
+@ResponseStatus(OK)
+@RequestMapping("/api/v1/scrap")
 public class ScrapRestController {
 
-  private final ScrapService scrapService;
+    private final ScrapService scrapService;
 
-  // 스크랩 등록 API
-  @PostMapping(value = "/register")
-  public ResponseEntity<ApiResponse<Void>> saveScrap(@RequestBody @Valid ScrapRegister request) {
-    scrapService.register(request.toService());
-    return ResponseEntity.ok().body(
-        ApiResponse.successResponse(
-            OK,
-            "성공적으로 혜택을 저장하였습니다."
-        )
-    );
-  }
+    /**
+     * 혜택 정보 스크랩
+     */
+    @PostMapping("/register")
+    public ApiResponse<Void> register(@RequestBody @Valid ScrapRegister request) {
+        scrapService.register(request.toService());
+        return ApiResponse.successResponse(OK, "성공적으로 혜택을 저장하였습니다.");
+    }
+
 }

--- a/src/main/resources/mapper/interest/InterestMapper.xml
+++ b/src/main/resources/mapper/interest/InterestMapper.xml
@@ -19,5 +19,8 @@
     WHERE MEMBER_ID = #{memberId}
   </select>
 
+  <delete id="deleteByMemberId">
+    DELETE FROM INTERESTS WHERE MEMBER_ID = #{memberId}
+  </delete>
 
 </mapper>

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -30,7 +30,7 @@
   </resultMap>
 
   <insert id="save" parameterType="Member" >
-    INSERT INTO MEMBERS (email, nick_name, password, age_range, gender, career, married_status, num_child, member_role)
+    INSERT INTO MEMBERS (EMAIL, NICK_NAME, PASSWORD, AGE_RANGE, GENDER, CAREER, MARRIED_STATUS, NUM_CHILD, MEMBER_ROLE)
     VALUES (#{email}, #{nickName}, #{password}, #{ageRange}, #{gender}, #{career}, #{marriedStatus}, #{numChild}, #{memberRole})
   </insert>
 
@@ -68,6 +68,11 @@
 
   <update id="updateAgeRangeById">
     UPDATE MEMBERS SET AGE_RANGE = #{ageRange}
+    WHERE MEMBER_ID = #{memberId}
+  </update>
+
+  <update id="updatePassword">
+    UPDATE MEMBERS SET PASSWORD = #{password}
     WHERE MEMBER_ID = #{memberId}
   </update>
 

--- a/src/main/resources/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mapper/member/MemberMapper.xml
@@ -76,4 +76,8 @@
     WHERE MEMBER_ID = #{memberId}
   </update>
 
+  <delete id="deleteById">
+    DELETE FROM MEMBERS WHERE MEMBER_ID = #{memberId}
+  </delete>
+
 </mapper>

--- a/src/main/resources/mapper/policy/PolicyMapper.xml
+++ b/src/main/resources/mapper/policy/PolicyMapper.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="sandbox.apricot.policy.mapper.PolicyMapper">
+
+  <resultMap id="DistrictPolicyResultMap" type="sandbox.apricot.policy.dto.response.DistrictPolicy">
+    <id property="districtName" column="DISTRICT_NAME" />
+    <result property="policyCnt" column="POLICY_CNT" />
+  </resultMap>
+
+  <select id="getPolicyCountByDistrict" resultMap="DistrictPolicyResultMap">
+    SELECT d.DISTRICT_NAME AS DISTRICT_NAME, COUNT(*) AS POLICY_CNT
+    FROM YOUTH_POLICY_DETAIL y
+    JOIN districts d ON y.DISTRICT_CODE = d.DISTRICT_CODE
+    GROUP BY d.DISTRICT_CODE, d.DISTRICT_NAME
+  </select>
+
+</mapper>

--- a/src/main/webapp/js/components/wordcloud.js
+++ b/src/main/webapp/js/components/wordcloud.js
@@ -8,7 +8,7 @@ document.addEventListener('DOMContentLoaded', function() {
     success: function (api) {
       const words = api.data.map(data => ({
         text: data.districtName,
-        count: data.policyCnt
+        count: data.policyCnt,
       }));
 
       var myConfig = {
@@ -56,6 +56,13 @@ document.addEventListener('DOMContentLoaded', function() {
         data: myConfig,
         height: '100%',
         width: '100%',
+      });
+
+      zingchart.bind('myChart', 'label_click', function(e) {
+        if (e.label) {
+          const district = e.label.text;
+          window.location.href = `${window.location.origin}/policy?search-name=${encodeURIComponent(district)}`;
+        }
       });
     },
     error: function (jqXHR, textStatus, errorThrown) {

--- a/src/main/webapp/js/components/wordcloud.js
+++ b/src/main/webapp/js/components/wordcloud.js
@@ -1,155 +1,65 @@
 ZC.LICENSE = ["569d52cefae586f634c54f86dc99e6a9", "b55b025e438fa8a98e32482b5f768ff5"];
 
 document.addEventListener('DOMContentLoaded', function() {
-  var myConfig = {
-    "graphset": [{
-      "type": "wordcloud",
-      backgroundColor: 'rgba(249,151,62,0)',
-      options: {
-        colorType: 'palette',
-        palette: ['#F9973E', '#375E97', '#FB6542', '#3F681C', '#FFBB00', '#FB7252'], //색상지정
-        aspect: 'spiral', //중앙 원형
-        maxFontSize: 80, //최대 글씨 크기
-        minFontSize: 20, //최소 글씨 크기
-        textSpacing: 0.1, //글짜 간격
-        "style": {
-          borderRadius: 10,
-          fontFamily: 'Jua',
-          //padding: '5px 10px',
-          hoverState: {
-            alpha: 1,
-            backgroundColor: 'rgba(249,151,62,0)',
-            borderColor: 'none',
-            fontColor: 'black',
-            textAlpha: 1,
-          },
 
-          "tooltip": {
-            visible: true,
-            text: '%text: %hits',
-            alpha: 0.9,
-            backgroundColor: 'purple',
-            borderColor: 'none',
-            borderRadius: 2,
-            fontColor: 'white',
-            fontSize: 12,
-            textAlpha: 1,
+  $.ajax({
+    url: 'api/v1/policy/word-cloud',
+    method: 'GET',
+    success: function (api) {
+      const words = api.data.map(data => ({
+        text: data.districtName,
+        count: data.policyCnt
+      }));
+
+      var myConfig = {
+        "graphset": [{
+          "type": "wordcloud",
+          backgroundColor: 'rgba(249,151,62,0)',
+          options: {
+            colorType: 'palette',
+            palette: ['#F9973E', '#375E97', '#FB6542', '#3F681C', '#FFBB00', '#FB7252'], //색상지정
+            aspect: 'spiral', //중앙 원형
+            maxFontSize: 80, //최대 글씨 크기
+            minFontSize: 20, //최소 글씨 크기
+            textSpacing: 0.1, //글짜 간격
+            "style": {
+              borderRadius: 10,
+              fontFamily: 'Jua',
+              //padding: '5px 10px',
+              hoverState: {
+                alpha: 1,
+                backgroundColor: 'rgba(249,151,62,0)',
+                borderColor: 'none',
+                fontColor: 'black',
+                textAlpha: 1,
+              },
+
+              "tooltip": {
+                visible: true,
+                text: '%text: %hits',
+                alpha: 0.9,
+                backgroundColor: 'purple',
+                borderColor: 'none',
+                borderRadius: 2,
+                fontColor: 'white',
+                fontSize: 12,
+                textAlpha: 1,
+              }
+            },
+            "words": words
           }
-        },
-        "words": [
-          // { //나중에 사용
-          //     "text": "서울시",
-          //     "count": "1000"
-          //   },
-          {
-            "text": "강서구",
-            "count": "342"
-          },
-          {
-            "text": "동대문구",
-            "count": "296"
-          },
-          {
-            "text": "종로구",
-            "count": "212"
-          },
-          {
-            "text": "중구",
-            "count": "201"
-          },
-          {
-            "text": "용산구",
-            "count": "183"
-          },
-          {
-            "text": "성동구",
-            "count": "130"
-          },
-          {
-            "text": "광진구",
-            "count": "405"
-          },
-          {
-            "text": "중랑구",
-            "count": "121"
-          },
-          {
-            "text": "성북구",
-            "count": "117"
-          },
-          {
-            "text": "강북구",
-            "count": "110"
-          },
-          {
-            "text": "도봉구",
-            "count": "103"
-          },
-          {
-            "text": "노원구",
-            "count": "98"
-          },
-          {
-            "text": "은평구",
-            "count": "95"
-          },
-          {
-            "text": "서대문구",
-            "count": "92"
-          },
-          {
-            "text": "마포구",
-            "count": "91"
-          },
-          {
-            "text": "양천구",
-            "count": "89"
-          },
-          {
-            "text": "구로구",
-            "count": "88"
-          },
-          {
-            "text": "금천구",
-            "count": "87"
-          },
-          {
-            "text": "영등포구",
-            "count": "85"
-          },
-          {
-            "text": "동작구",
-            "count": "83"
-          },
-          {
-            "text": "관악구",
-            "count": "81"
-          },
-          {
-            "text": "서초구",
-            "count": "79"
-          },
-          {
-            "text": "강남구",
-            "count": "78"
-          },
-          {
-            "text": "송파구",
-            "count": "75"
-          },
-          {
-            "text": "강동구",
-            "count": "73"
-          },
-        ]
-      }
-    }]
-  };
+        }]
+      };
 
-  zingchart.render({
-    id: 'myChart',
-    data: myConfig,
-    height: '100%',
-    width: '100%',
+      zingchart.render({
+        id: 'myChart',
+        data: myConfig,
+        height: '100%',
+        width: '100%',
+      });
+    },
+    error: function (jqXHR, textStatus, errorThrown) {
+      console.error('Error fetching word cloud data:', textStatus, errorThrown);
+    }
   });
 });

--- a/src/main/webapp/js/member/login.js
+++ b/src/main/webapp/js/member/login.js
@@ -14,16 +14,15 @@ $(document).ready(() => {
       success: function () {
         window.location.href = '/'; // 로그인 성공 시 홈
       },
-      error: function (xhr, status, error) {
+      error: function (xhr) {
         let errorMessage;
         try {
           const responseJSON = JSON.parse(xhr.responseText);
-          errorMessage = responseJSON.error;
+          errorMessage = responseJSON.message;
         } catch (e) {
           errorMessage = "알 수 없는 오류가 발생하였습니다.";
         }
         $('#loginErrorMessage').text(errorMessage).show();
-        console.error('AJAX Error:', status, error); // AJAX 요청의 상태 및 오류 출력
       }
     });
   });


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close: #32
- #48 

<br>

## 💡 Key Changes
### 1️⃣ 회원 수정, 삭제에 대한 RestAPI 개발
- 등록된 회원에 대한 정보를 수정하고 삭제하는 기능의 API 개발을 진행하였습니다. 

### 2️⃣ 지역구별 혜택 조회 기능 개발(워드클라우드 적용)
- 지역구별 혜택 수를 워드 클라우드로 출력할 수 있도록 조회 기능을 개발하였습니다.

### 3️⃣ 로그인시 이메일, 비밀번호에 대한 예외 처리 수정
- 존재하지 않는 이메일 작성, 존재하지만 잘못된 비밀번호로 로그인을 시도할 시 Login 페이지 상단에 "아이디 또는 비밀번호가 일치하지 않습니다."를 출력하도록 예외처리를 수정하였습니다.

<br>

## ➕ ETC 
- BE기능이므로, FE의 연결 작업은 필요함
- Security 예외처리시 Controller 에서 발생하는 RuntimeException 처리는 무관한 것을 알 수 있었습니다. GlobalExceptionHandler의 경우 Controller 까지 흐름이 진행되어야 하는데 Security의 경우 Filter에서 발생하는 예외이기 때문에 해당 예외는 별도로 설정해야 했습니다. 
