### PR TITLE
[Feat] 정책 추천 기능 연동

### DIFF
--- a/src/main/java/sandbox/apricot/policy/controller/PolicyController.java
+++ b/src/main/java/sandbox/apricot/policy/controller/PolicyController.java
@@ -66,6 +66,7 @@ public class PolicyController {
         PolicyDetailDTO policyDetails = policyService.getPolicyDetailsByCode(policyCode);
         model.addAttribute("policyDetails", policyDetails);
 
+        // 조회 중인 정책과 같은 카테고리의 랜덤한 정책 3개 추천
         List<PolicyScoreDTO> recommendations = recommendationService.getPolicyRecommendation(
                 policyCode);
 
@@ -79,12 +80,13 @@ public class PolicyController {
         model.addAttribute("secondPolicyRecommendation", secondPolicy);
         model.addAttribute("thirdPolicyRecommendation", thirdPolicy);
 
-        District district1 = policyService.getDistrict(recommendations.get(0).getDistrictCode());
-        District district2 = policyService.getDistrict(recommendations.get(1).getDistrictCode());
-        District district3 = policyService.getDistrict(recommendations.get(2).getDistrictCode());
-        model.addAttribute("district1", district1);
-        model.addAttribute("district2", district2);
-        model.addAttribute("district3", district3);
+        // 각 정책에 해당하는 지역구
+        District firstPolicyDistrict = policyService.getDistrict(recommendations.get(0).getDistrictCode());
+        District secondPolicyDistrict = policyService.getDistrict(recommendations.get(1).getDistrictCode());
+        District thirdPolicyDistrict = policyService.getDistrict(recommendations.get(2).getDistrictCode());
+        model.addAttribute("firstPolicyDistrict", firstPolicyDistrict);
+        model.addAttribute("secondPolicyDistrict", secondPolicyDistrict);
+        model.addAttribute("thirdPolicyDistrict", thirdPolicyDistrict);
 
         //로그인 된 사람에게만 정보 넘기기 위해 사 용
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/sandbox/apricot/policy/controller/PolicyController.java
+++ b/src/main/java/sandbox/apricot/policy/controller/PolicyController.java
@@ -17,6 +17,8 @@ import sandbox.apricot.policy.dto.response.PolicyInfo;
 import sandbox.apricot.policy.service.PolicyService;
 
 import java.util.List;
+import sandbox.apricot.recommendation.dto.response.PolicyScoreDTO;
+import sandbox.apricot.recommendation.service.RecommendationService;
 import sandbox.apricot.scrap.dto.response.ScrapInfo;
 import sandbox.apricot.scrap.service.ScrapService;
 import sandbox.apricot.policy.dto.response.PolicyDetailDTO;
@@ -29,6 +31,7 @@ public class PolicyController {
     private final PolicyService policyService;
     private final MemberService memberService;
     private final ScrapService scrapService;
+    private final RecommendationService recommendationService;
 
     //정책 검색 페이지
     @GetMapping("/searchpolicy")
@@ -63,7 +66,27 @@ public class PolicyController {
         PolicyDetailDTO policyDetails = policyService.getPolicyDetailsByCode(policyCode);
         model.addAttribute("policyDetails", policyDetails);
 
-        //로그인 된 사람에게만 정보 넘기기 위해 사용
+        List<PolicyScoreDTO> recommendations = recommendationService.getPolicyRecommendation(
+                policyCode);
+
+        PolicyDetailDTO firstPolicy = policyService.getPolicyDetailsByCode(
+                recommendations.get(0).getPolicyCode());
+        PolicyDetailDTO secondPolicy = policyService.getPolicyDetailsByCode(
+                recommendations.get(1).getPolicyCode());
+        PolicyDetailDTO thirdPolicy = policyService.getPolicyDetailsByCode(
+                recommendations.get(2).getPolicyCode());
+        model.addAttribute("firstPolicyRecommendation", firstPolicy);
+        model.addAttribute("secondPolicyRecommendation", secondPolicy);
+        model.addAttribute("thirdPolicyRecommendation", thirdPolicy);
+
+        District district1 = policyService.getDistrict(recommendations.get(0).getDistrictCode());
+        District district2 = policyService.getDistrict(recommendations.get(1).getDistrictCode());
+        District district3 = policyService.getDistrict(recommendations.get(2).getDistrictCode());
+        model.addAttribute("district1", district1);
+        model.addAttribute("district2", district2);
+        model.addAttribute("district3", district3);
+
+        //로그인 된 사람에게만 정보 넘기기 위해 사 용
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String userName = null;
 

--- a/src/main/java/sandbox/apricot/recommendation/controller/RecommendationController.java
+++ b/src/main/java/sandbox/apricot/recommendation/controller/RecommendationController.java
@@ -19,7 +19,8 @@ public class RecommendationController {
 
     // 지역구 추천
     @GetMapping
-    public String viewRecommend(Model model, @AuthenticationPrincipal MemberPrincipalDetails member) {
+    public String viewRecommend(Model model,
+            @AuthenticationPrincipal MemberPrincipalDetails member) {
         Long memberId = member.getMember().getMemberId();
         MemberInfo memberInfo = memberService.getMemberInfo(memberId);
         model.addAttribute("memberInfo", memberInfo);

--- a/src/main/resources/mapper/recommendation/Recommendation.xml
+++ b/src/main/resources/mapper/recommendation/Recommendation.xml
@@ -13,8 +13,8 @@
     <result property="originalAgeRange" column="GROUP1_AGE_RANGE"/>
     <result property="comparisonGender" column="GROUP2_GENDER"/>
     <result property="comparisonAgeRange" column="GROUP2_AGE_RANGE"/>
-    <result property="preferenceCount" column="preferenceCount"/>
-    <result property="cosineSimilarity" column="cosineSimilarity"/>
+    <result property="preferenceCount" column="PREFERENCE_COUNT"/>
+    <result property="cosineSimilarity" column="COSINE_SIMILARITY"/>
   </resultMap>
 
   <resultMap id="PolicyScoreMap" type="PolicyScoreDTO">
@@ -125,7 +125,8 @@
           (SELECT CATEGORY_CODE FROM YOUTH_POLICY_DETAIL WHERE POLICY_CODE = #{policyCode})
       AND district_code != '26'
       AND POLICY_CODE != #{policyCode}
-    ORDER BY avg_score DESC
+    ORDER BY DBMS_RANDOM.VALUE
+    FETCH first 3 rows only
   </select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/policy/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/policy/detail.jsp
@@ -5,353 +5,369 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-  <meta charset="UTF-8">
-  <title>정책 지원 페이지</title>
-  <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/common-env.jsp"/>
-  <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/detail-env.jsp"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="UTF-8">
+    <title>정책 지원 페이지</title>
+    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/common-env.jsp"/>
+    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/detail-env.jsp"/>
+    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/policy-env.jsp"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <jsp:include page="${pageContext.request.contextPath}/WEB-INF/components/header.jsp"/>
 <div class="hidden-background"></div>
 <div class="layout">
-  <div class="navmenu-wrapper">
-    <nav class="navmenu">
-      <ul>
-        <li><a href="#section1" id="navitem1" class="active"><img src="/assets/img/mascot.png" width="40"><span>한 눈에 보는 정책 요약</span></a>
-        </li>
-        <li><a href="#section2" id="navitem2"><img src="/assets/img/mascot.png" width="40"><span>신청자격</span></a>
-        </li>
-        <li><a href="#section3" id="navitem3"><img src="/assets/img/mascot.png" width="40"><span>신청방법</span></a>
-        </li>
-        <li><a href="#section4" id="navitem4"><img src="/assets/img/mascot.png" width="40"><span>기타</span></a></li>
-      </ul>
-    </nav>
-  </div>
-  <div class="policy-detail-page">
-    <div class="policy-header">
-      <sec:authorize access="isAuthenticated()">
-        <div class="icon">
-          <label class="container">
-            <input type="checkbox"
-                   id="scrapCheck"
-                <c:if test="${not empty scrapInfo}">
-                  <c:forEach items="${scrapInfo}" var="scrap">
-                    <c:if test="${scrap.policyCode == policyDetails.policyCode}">
-                      checked
-                    </c:if>
-                  </c:forEach>
-                </c:if>
-            />
-            <div class="check" data-policy-code="${policyDetails.policyCode}"
-                <c:if test="${not empty scrapInfo}">
-                  <c:forEach items="${scrapInfo}" var="scrap">
-                    <c:if test="${scrap.policyCode == policyDetails.policyCode}">
-                      data-scrap-id="${scrap.scrapId}"
-                    </c:if>
-                  </c:forEach>
-                </c:if>
-            >
-              <svg viewBox="0 0 256 256">
-                <rect fill="none" height="256" width="256"></rect>
-                <path
-                    d="M224.6,51.9a59.5,59.5,0,0,0-43-19.9,60.5,60.5,0,0,0-44,17.6L128,59.1l-7.5-7.4C97.2,28.3,59.2,26.3,35.9,47.4a59.9,59.9,0,0,0-2.3,87l83.1,83.1a15.9,15.9,0,0,0,22.6,0l81-81C243.7,113.2,245.6,75.2,224.6,51.9Z"
-                    stroke-width="20px"
-                    stroke="#000"
-                    fill="none"
-                ></path>
-              </svg>
-            </div>
-          </label>
-        </div>
-      </sec:authorize>
-      <div class="policy-title">
-        <h2>${policyDetails.policyName !="null" && !policyDetails.policyName.isEmpty()? policyDetails.policyName:"❌"}</h2>
-        <h3>${policyDetails.policyContent !="null" && !policyDetails.policyContent.isEmpty()? policyDetails.policyContent:"❌"}</h3>
-      </div>
-      <div class="button-link">
-      </div>
+    <div class="navmenu-wrapper">
+        <nav class="navmenu">
+            <ul>
+                <li><a href="#section1" id="navitem1" class="active"><img
+                        src="/assets/img/mascot.png" width="40"><span>한 눈에 보는 정책 요약</span></a>
+                </li>
+                <li><a href="#section2" id="navitem2"><img src="/assets/img/mascot.png"
+                                                           width="40"><span>신청자격</span></a>
+                </li>
+                <li><a href="#section3" id="navitem3"><img src="/assets/img/mascot.png"
+                                                           width="40"><span>신청방법</span></a>
+                </li>
+                <li><a href="#section4" id="navitem4"><img src="/assets/img/mascot.png"
+                                                           width="40"><span>기타</span></a></li>
+            </ul>
+        </nav>
     </div>
-
-    <div class="policy-table-content" id="section1">
-      <div class="policy-table-header">
-        <h3>한 눈에 보는 정책 요약</h3>
-      </div>
-      <ul>
-        <li>
-          <div class="list-container">
-            <div class="list-title">정책 번호</div>
-            <div class="list-content">${policyDetails.policyCode !="null" && !policyDetails.policyCode.isEmpty()? policyDetails.policyCode:"❌"}</div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">정책 분야</div>
-            <div class="list-content">${policyDetails.categoryCode !="null" && !policyDetails.categoryCode.isEmpty()? policyDetails.categoryCode:"❌"}</div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">사업 운영 기간</div>
-            <div class="list-content">${policyDetails.prdRpttSecd !="null" && !policyDetails.prdRpttSecd.isEmpty()? policyDetails.prdRpttSecd:"❌"}</div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">사업 신청 기간</div>
-            <div class="list-content">${policyDetails.schedule !="null" && !policyDetails.schedule.isEmpty()? policyDetails.schedule:"❌"}</div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">지원 규모</div>
-            <div class="list-content">something here sometimes</div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">지원 내용</div>
-            <div class="list-content">
-              ${policyDetails.supportContent !="null" && !policyDetails.supportContent.isEmpty()? policyDetails.supportContent:"❌"}
+    <div class="policy-detail-page">
+        <div class="policy-header">
+            <sec:authorize access="isAuthenticated()">
+                <div class="icon">
+                    <label class="container">
+                        <input type="checkbox"
+                               id="scrapCheck"
+                                <c:if test="${not empty scrapInfo}">
+                                    <c:forEach items="${scrapInfo}" var="scrap">
+                                        <c:if test="${scrap.policyCode == policyDetails.policyCode}">
+                                            checked
+                                        </c:if>
+                                    </c:forEach>
+                                </c:if>
+                        />
+                        <div class="check" data-policy-code="${policyDetails.policyCode}"
+                                <c:if test="${not empty scrapInfo}">
+                                    <c:forEach items="${scrapInfo}" var="scrap">
+                                        <c:if test="${scrap.policyCode == policyDetails.policyCode}">
+                                            data-scrap-id="${scrap.scrapId}"
+                                        </c:if>
+                                    </c:forEach>
+                                </c:if>
+                        >
+                            <svg viewBox="0 0 256 256">
+                                <rect fill="none" height="256" width="256"></rect>
+                                <path
+                                        d="M224.6,51.9a59.5,59.5,0,0,0-43-19.9,60.5,60.5,0,0,0-44,17.6L128,59.1l-7.5-7.4C97.2,28.3,59.2,26.3,35.9,47.4a59.9,59.9,0,0,0-2.3,87l83.1,83.1a15.9,15.9,0,0,0,22.6,0l81-81C243.7,113.2,245.6,75.2,224.6,51.9Z"
+                                        stroke-width="20px"
+                                        stroke="#000"
+                                        fill="none"
+                                ></path>
+                            </svg>
+                        </div>
+                    </label>
+                </div>
+            </sec:authorize>
+            <div class="policy-title">
+                <h2>${policyDetails.policyName !="null" && policyDetails.policyName !=null && !policyDetails.policyName.isEmpty()? policyDetails.policyName:"❌"}</h2>
+                <h3>${policyDetails.policyContent !="null" && policyDetails.policyContent !=null && !policyDetails.policyContent.isEmpty()? policyDetails.policyContent:"❌"}</h3>
             </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">비고</div>
-            <div class="list-content">
-              something something
+            <div class="button-link">
             </div>
-          </div>
-        </li>
-
-      </ul>
-    </div>
-
-    <div class="policy-table-content" id="section2">
-      <div class="policy-table-header">
-        <h3>신청자격</h3>
-      </div>
-      <ul>
-        <li>
-          <div class="list-container">
-            <div class="list-title">연령</div>
-            <div class="list-content">${policyDetails.ageInfo !="null" && !policyDetails.ageInfo.isEmpty()? policyDetails.ageInfo:"❌"}</div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">취업 상태</div>
-            <div class="list-content">
-              ${policyDetails.empmSttsCn !="null" && !policyDetails.empmSttsCn.isEmpty()? policyDetails.empmSttsCn:"❌"}
-            </div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">학력</div>
-            <div class="list-content">
-              ${policyDetails.accrRqisCn !="null" && !policyDetails.accrRqisCn.isEmpty()? policyDetails.accrRqisCn:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">전공</div>
-            <div class="list-content">
-              ${policyDetails.majorRqisCn !="null" && !policyDetails.majorRqisCn.isEmpty()? policyDetails.majorRqisCn:"❌"}
-            </div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">특화 분야</div>
-            <div class="list-content">
-              ${policyDetails.splzRlmRqisCn !="null" && !policyDetails.splzRlmRqisCn.isEmpty()? policyDetails.splzRlmRqisCn:"❌"}
-            </div>
-          </div>
-
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">거주지 및 소득</div>
-            <div class="list-content">
-              ${policyDetails.prcpCn !="null" && !policyDetails.prcpCn.isEmpty()? policyDetails.prcpCn:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">참여 제한 대상</div>
-            <div class="list-content">
-              ${policyDetails.prcpLmttTrgtCn !="null" && !policyDetails.prcpLmttTrgtCn.isEmpty()? policyDetails.prcpLmttTrgtCn:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">추가 단서 사항</div>
-            <div class="list-content">
-              ${policyDetails.aditRscn !="null" && !policyDetails.aditRscn.isEmpty()? policyDetails.aditRscn:"❌"}
-
-            </div>
-          </div>
-        </li>
-
-
-      </ul>
-    </div>
-
-    <div class="policy-table-content" id="section3">
-      <div class="policy-table-header">
-        <h3>신청방법</h3>
-      </div>
-      <ul>
-        <li>
-          <div class="list-container">
-            <div class="list-title">신청 절차</div>
-            <div class="list-content">
-              ${policyDetails.rqutProcCn !="null" && !policyDetails.rqutProcCn.isEmpty()? policyDetails.rqutProcCn:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">심사 및 발표</div>
-            <div class="list-content">
-              ${policyDetails.jdgnPresCn !="null" && !policyDetails.jdgnPresCn.isEmpty()? policyDetails.jdgnPresCn:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">신청 사이트</div>
-            <div class="list-content">
-              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-              <c:if test="${policyDetails.rqutUrla != 'null' && !policyDetails.rqutUrla.isEmpty()}">
-                <a href="${policyDetails.rqutUrla}">${policyDetails.rqutUrla}</a>
-              </c:if>
-
-              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-              <c:if test="${policyDetails.rqutUrla == 'null' || policyDetails.rqutUrla.isEmpty()}">
-                ❌
-              </c:if>
-
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">제출 서류</div>
-            <div class="list-content">
-              ${policyDetails.pstnPaprCn !="null" && !policyDetails.pstnPaprCn.isEmpty()? policyDetails.pstnPaprCn:"❌"}
-            </div>
-          </div>
-      </ul>
-    </div>
-    <div class="policy-table-content" id="section4">
-      <div class="policy-table-header">
-        <h3>기타</h3>
-      </div>
-      <ul>
-        <li>
-          <div class="list-container">
-            <div class="list-title">기타 유익 정보</div>
-            <div class="list-content">
-              ${policyDetails.etct !="null" && !policyDetails.etct.isEmpty()? policyDetails.etct:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">주관 기관</div>
-            <div class="list-content">
-              ${policyDetails.mngtMson !="null" && !policyDetails.mngtMson.isEmpty()? policyDetails.mngtMson:"❌"}
-            </div>
-          </div>
-          <div class="list-container">
-            <div class="list-title">운영 기관</div>
-            <div class="list-content">
-              ${policyDetails.cnsgNmor !="null" && !policyDetails.cnsgNmor.isEmpty()? policyDetails.cnsgNmor:"❌"}
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">사업관련 참고 사이트1</div>
-            <div class="list-content">
-              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-              <c:if test="${policyDetails.rfcSiteUrla1 != 'null' && !policyDetails.rfcSiteUrla1.isEmpty()}">
-                <a href="${policyDetails.rfcSiteUrla1}">${policyDetails.rfcSiteUrla1}</a>
-              </c:if>
-
-              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-              <c:if test="${policyDetails.rfcSiteUrla1 == 'null' || policyDetails.rfcSiteUrla1.isEmpty()}">
-                ❌
-              </c:if>
-
-            </div>
-          </div>
-        </li>
-        <li>
-          <div class="list-container">
-            <div class="list-title">사업관련 참고 사이트2</div>
-            <div class="list-content">
-
-              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-              <c:if test="${policyDetails.rfcSiteUrla2 != 'null' && !policyDetails.rfcSiteUrla2.isEmpty()}">
-                <a href="${policyDetails.rfcSiteUrla2}">${policyDetails.rfcSiteUrla2}</a>
-              </c:if>
-
-              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-              <c:if test="${policyDetails.rfcSiteUrla2 == 'null' || policyDetails.rfcSiteUrla2.isEmpty()}">
-                ❌
-              </c:if>
-            </div>
-          </div>
-        </li>
-      </ul>
-    </div>
-
-    <div class="top-areas">
-      <h2>지금 보고 있는 혜택 이용자 평점</h2>
-      <div class="avg-score" id="avg-score" data-score="${policyDetails.avgPolicyScore}">${policyDetails.avgPolicyScore}</div>
-      <div class="rating">
-        <input type="radio" id="star5" name="rating" value="5" disabled>
-        <label for="star5" class="${policyDetails.avgPolicyScore >= 5 ? 'filled' : ''}"></label>
-        <input type="radio" id="star4" name="rating" value="4" disabled>
-        <label for="star4" class="${policyDetails.avgPolicyScore >= 4 ? 'filled' : ''}"></label>
-        <input type="radio" id="star3" name="rating" value="3" disabled>
-        <label for="star3" class="${policyDetails.avgPolicyScore >= 3 ? 'filled' : ''}"></label>
-        <input type="radio" id="star2" name="rating" value="2" disabled>
-        <label for="star2" class="${policyDetails.avgPolicyScore >= 2 ? 'filled' : ''}"></label>
-        <input type="radio" id="star1" name="rating" value="1" disabled>
-        <label for="star1" class="${policyDetails.avgPolicyScore >= 1 ? 'filled' : ''}"></label>
-      </div>
-    </div>
-
-    <div class="top-areas">
-      <h2>지금 보고 있는 혜택과 비슷한 혜택</h2>
-      <div class="areas-list">
-        <div class="area-item">
-          <div class="area-container">
-            <img src="${pageContext.request.contextPath}/assets/img/gangnam.png" alt="지역구"/>
-          </div>
-          <div class="text">
-            <p class="region-name">강남구</p>
-            <p class="region-tag">#역세권 1위!</p>
-          </div>
-        </div>
-        <div class="area-item">
-          <div class="area-container">
-            <img src="${pageContext.request.contextPath}/assets/img/gangnam.png" alt="지역구"/>
-          </div>
-          <div class="text">
-            <p class="region-name">강남구</p>
-            <p class="region-tag">#역세권 1위!</p>
-          </div>
-        </div>
-        <div class="area-item">
-          <div class="area-container">
-            <img src="${pageContext.request.contextPath}/assets/img/gangnam.png" alt="지역구"/>
-          </div>
-          <div class="text">
-            <p class="region-name">강남구</p>
-            <p class="region-tag">#역세권 1위!</p>
-          </div>
         </div>
 
-      </div>
+        <div class="policy-table-content" id="section1">
+            <div class="policy-table-header">
+                <h3>한 눈에 보는 정책 요약</h3>
+            </div>
+            <ul>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">정책 번호</div>
+                        <div class="list-content">${policyDetails.policyCode !="null" && policyDetails.policyCode !=null && !policyDetails.policyCode.isEmpty()? policyDetails.policyCode:"❌"}</div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">정책 분야</div>
+                        <div class="list-content">${policyDetails.categoryCode !="null" && policyDetails.categoryCode !=null && !policyDetails.categoryCode.isEmpty()? policyDetails.categoryCode:"❌"}</div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">사업 운영 기간</div>
+                        <div class="list-content">${policyDetails.prdRpttSecd !="null" && policyDetails.prdRpttSecd !=null && !policyDetails.prdRpttSecd.isEmpty()? policyDetails.prdRpttSecd:"❌"}</div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">사업 신청 기간</div>
+                        <div class="list-content">${policyDetails.schedule !="null" && policyDetails.schedule !=null && !policyDetails.schedule.isEmpty()? policyDetails.schedule:"❌"}</div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">지원 규모</div>
+                        <div class="list-content">something here sometimes</div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">지원 내용</div>
+                        <div class="list-content">
+                            ${policyDetails.supportContent !="null" && policyDetails.supportContent !=null && !policyDetails.supportContent.isEmpty()? policyDetails.supportContent:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">비고</div>
+                        <div class="list-content">
+                            something something
+                        </div>
+                    </div>
+                </li>
+
+            </ul>
+        </div>
+
+        <div class="policy-table-content" id="section2">
+            <div class="policy-table-header">
+                <h3>신청자격</h3>
+            </div>
+            <ul>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">연령</div>
+                        <div class="list-content">${policyDetails.ageInfo !="null" && policyDetails.ageInfo !=null && !policyDetails.ageInfo.isEmpty()? policyDetails.ageInfo:"❌"}</div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">취업 상태</div>
+                        <div class="list-content">
+                            ${policyDetails.empmSttsCn !="null" && policyDetails.empmSttsCn !=null && !policyDetails.empmSttsCn.isEmpty()? policyDetails.empmSttsCn:"❌"}
+                        </div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">학력</div>
+                        <div class="list-content">
+                            ${policyDetails.accrRqisCn!="null" && policyDetails.accrRqisCn!=null && !policyDetails.accrRqisCn.isEmpty()? policyDetails.accrRqisCn:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">전공</div>
+                        <div class="list-content">
+                            ${policyDetails.majorRqisCn!="null" && policyDetails.majorRqisCn!=null && !policyDetails.majorRqisCn.isEmpty()? policyDetails.majorRqisCn:"❌"}
+                        </div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">특화 분야</div>
+                        <div class="list-content">
+                            ${policyDetails.splzRlmRqisCn !="null" && policyDetails.splzRlmRqisCn !=null &&!policyDetails.splzRlmRqisCn.isEmpty()? policyDetails.splzRlmRqisCn:"❌"}
+                        </div>
+                    </div>
+
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">거주지 및 소득</div>
+                        <div class="list-content">
+                            ${policyDetails.prcpCn !="null" && policyDetails.prcpCn !=null && !policyDetails.prcpCn.isEmpty()? policyDetails.prcpCn:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">참여 제한 대상</div>
+                        <div class="list-content">
+                            ${policyDetails.prcpLmttTrgtCn !="null" && policyDetails.prcpLmttTrgtCn !=null && !policyDetails.prcpLmttTrgtCn.isEmpty()? policyDetails.prcpLmttTrgtCn:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">추가 단서 사항</div>
+                        <div class="list-content">
+                            ${policyDetails.aditRscn !="null" && policyDetails.aditRscn !=null && !policyDetails.aditRscn.isEmpty()? policyDetails.aditRscn:"❌"}
+
+                        </div>
+                    </div>
+                </li>
+
+
+            </ul>
+        </div>
+
+        <div class="policy-table-content" id="section3">
+            <div class="policy-table-header">
+                <h3>신청방법</h3>
+            </div>
+            <ul>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">신청 절차</div>
+                        <div class="list-content">
+                            ${policyDetails.rqutProcCn !="null" && policyDetails.rqutProcCn !=null && !policyDetails.rqutProcCn.isEmpty()? policyDetails.rqutProcCn:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">심사 및 발표</div>
+                        <div class="list-content">
+                            ${policyDetails.jdgnPresCn !="null" && policyDetails.jdgnPresCn !=null && !policyDetails.jdgnPresCn.isEmpty()? policyDetails.jdgnPresCn:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">신청 사이트</div>
+                        <div class="list-content">
+                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+                            <c:if test="${policyDetails.rqutUrla != 'null' && policyDetails.rqutUrla != null && !policyDetails.rqutUrla.isEmpty()}">
+                                <a href="${policyDetails.rqutUrla}">${policyDetails.rqutUrla}</a>
+                            </c:if>
+
+                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+                            <c:if test="${policyDetails.rqutUrla == 'null' || policyDetails.rqutUrla == null || policyDetails.rqutUrla.isEmpty()}">
+                                ❌
+                            </c:if>
+
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">제출 서류</div>
+                        <div class="list-content">
+                            ${policyDetails.pstnPaprCn !="null" && policyDetails.pstnPaprCn !=null && !policyDetails.pstnPaprCn.isEmpty()? policyDetails.pstnPaprCn:"❌"}
+                        </div>
+                    </div>
+            </ul>
+        </div>
+        <div class="policy-table-content" id="section4">
+            <div class="policy-table-header">
+                <h3>기타</h3>
+            </div>
+            <ul>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">기타 유익 정보</div>
+                        <div class="list-content">
+                            ${policyDetails.etct !="null" && policyDetails.etct !=null && !policyDetails.etct.isEmpty()? policyDetails.etct:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">주관 기관</div>
+                        <div class="list-content">
+                            ${policyDetails.mngtMson !="null" && policyDetails.mngtMson !=null && !policyDetails.mngtMson.isEmpty()? policyDetails.mngtMson:"❌"}
+                        </div>
+                    </div>
+                    <div class="list-container">
+                        <div class="list-title">운영 기관</div>
+                        <div class="list-content">
+                            ${policyDetails.cnsgNmor !="null" && policyDetails.cnsgNmor !=null && !policyDetails.cnsgNmor.isEmpty()? policyDetails.cnsgNmor:"❌"}
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">사업관련 참고 사이트1</div>
+                        <div class="list-content">
+                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+                            <c:if test="${policyDetails.rfcSiteUrla1 != 'null' && policyDetails.rfcSiteUrla1 != null && !policyDetails.rfcSiteUrla1.isEmpty()}">
+                                <a href="${policyDetails.rfcSiteUrla1}">${policyDetails.rfcSiteUrla1}</a>
+                            </c:if>
+
+                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+                            <c:if test="${policyDetails.rfcSiteUrla1 == 'null' || policyDetails.rfcSiteUrla1 == null || policyDetails.rfcSiteUrla1.isEmpty()}">
+                                ❌
+                            </c:if>
+
+                        </div>
+                    </div>
+                </li>
+                <li>
+                    <div class="list-container">
+                        <div class="list-title">사업관련 참고 사이트2</div>
+                        <div class="list-content">
+
+                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+                            <c:if test="${policyDetails.rfcSiteUrla2 != 'null' && policyDetails.rfcSiteUrla2 != null && !policyDetails.rfcSiteUrla2.isEmpty()}">
+                                <a href="${policyDetails.rfcSiteUrla2}">${policyDetails.rfcSiteUrla2}</a>
+                            </c:if>
+
+                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+                            <c:if test="${policyDetails.rfcSiteUrla2 == 'null' || policyDetails.rfcSiteUrla2 == null ||policyDetails.rfcSiteUrla2.isEmpty()}">
+                                ❌
+                            </c:if>
+                        </div>
+                    </div>
+                </li>
+            </ul>
+        </div>
+        <div class="top-areas">
+            <h2>지금 보고 있는 혜택 이용자 평점</h2>
+            <div class="avg-score" id="avg-score"
+                 data-score="${policyDetails.avgPolicyScore}">${policyDetails.avgPolicyScore}</div>
+            <div class="rating">
+                <input type="radio" id="star5" name="rating" value="5" disabled>
+                <label for="star5"
+                       class="${policyDetails.avgPolicyScore >= 5 ? 'filled' : ''}"></label>
+                <input type="radio" id="star4" name="rating" value="4" disabled>
+                <label for="star4"
+                       class="${policyDetails.avgPolicyScore >= 4 ? 'filled' : ''}"></label>
+                <input type="radio" id="star3" name="rating" value="3" disabled>
+                <label for="star3"
+                       class="${policyDetails.avgPolicyScore >= 3 ? 'filled' : ''}"></label>
+                <input type="radio" id="star2" name="rating" value="2" disabled>
+                <label for="star2"
+                       class="${policyDetails.avgPolicyScore >= 2 ? 'filled' : ''}"></label>
+                <input type="radio" id="star1" name="rating" value="1" disabled>
+                <label for="star1"
+                       class="${policyDetails.avgPolicyScore >= 1 ? 'filled' : ''}"></label>
+            </div>
+        </div>
+        <div class="top-areas">
+            <h2>지금 보고 있는 혜택과 비슷한 혜택</h2>
+            <%-- 같은 카테고리인 정책 랜덤 추천--%>
+            <div class="areas-list">
+                <div class="area-item"
+                     onclick="goToPolicy('${firstPolicyRecommendation.policyCode}')">
+                    <div class="area-container">
+                        <img src="${pageContext.request.contextPath}${district1.districtLogoPath}"
+                             alt="${district1.districtName}"/>
+                    </div>
+                    <div class="text">
+                        <p class="region-name">${firstPolicyRecommendation.policyName}</p>
+                        <p class="region-tag">${firstPolicyRecommendation.policyContent}</p>
+                    </div>
+                </div>
+                <div class="area-item"
+                     onclick="goToPolicy('${secondPolicyRecommendation.policyCode}')">
+                    <div class="area-container">
+                        <img src="${pageContext.request.contextPath}${district2.districtLogoPath}"
+                             alt="${district2.districtName}"/>
+                    </div>
+                    <div class="text">
+                        <p class="region-name">${secondPolicyRecommendation.policyName}</p>
+                        <p class="region-tag">${secondPolicyRecommendation.policyContent}</p>
+                    </div>
+                </div>
+                <div class="area-item"
+                     onclick="goToPolicy('${thirdPolicyRecommendation.policyCode}')">
+                    <div class="area-container">
+                        <img src="${pageContext.request.contextPath}${district3.districtLogoPath}"
+                             alt="${district3.districtName}"/>
+                    </div>
+                    <div class="text">
+                        <p class="region-name">${thirdPolicyRecommendation.policyName}</p>
+                        <p class="region-tag">${thirdPolicyRecommendation.policyContent}</p>
+                    </div>
+                </div>
+
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
 <jsp:include page="${pageContext.request.contextPath}/WEB-INF/components/footer.jsp"/>

--- a/src/main/webapp/WEB-INF/views/policy/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/policy/detail.jsp
@@ -5,369 +5,380 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8">
-    <title>정책 지원 페이지</title>
-    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/common-env.jsp"/>
-    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/detail-env.jsp"/>
-    <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/policy-env.jsp"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8">
+  <title>정책 지원 페이지</title>
+  <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/common-env.jsp"/>
+  <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/detail-env.jsp"/>
+  <jsp:include page="${pageContext.request.contextPath}/WEB-INF/env/policy-env.jsp"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body>
 <jsp:include page="${pageContext.request.contextPath}/WEB-INF/components/header.jsp"/>
 <div class="hidden-background"></div>
 <div class="layout">
-    <div class="navmenu-wrapper">
-        <nav class="navmenu">
-            <ul>
-                <li><a href="#section1" id="navitem1" class="active"><img
-                        src="/assets/img/mascot.png" width="40"><span>한 눈에 보는 정책 요약</span></a>
-                </li>
-                <li><a href="#section2" id="navitem2"><img src="/assets/img/mascot.png"
-                                                           width="40"><span>신청자격</span></a>
-                </li>
-                <li><a href="#section3" id="navitem3"><img src="/assets/img/mascot.png"
-                                                           width="40"><span>신청방법</span></a>
-                </li>
-                <li><a href="#section4" id="navitem4"><img src="/assets/img/mascot.png"
-                                                           width="40"><span>기타</span></a></li>
-            </ul>
-        </nav>
+  <div class="navmenu-wrapper">
+    <nav class="navmenu">
+      <ul>
+        <li><a href="#section1" id="navitem1" class="active"><img
+            src="/assets/img/mascot.png" width="40"><span>한 눈에 보는 정책 요약</span></a>
+        </li>
+        <li><a href="#section2" id="navitem2"><img src="/assets/img/mascot.png"
+                                                   width="40"><span>신청자격</span></a>
+        </li>
+        <li><a href="#section3" id="navitem3"><img src="/assets/img/mascot.png"
+                                                   width="40"><span>신청방법</span></a>
+        </li>
+        <li><a href="#section4" id="navitem4"><img src="/assets/img/mascot.png"
+                                                   width="40"><span>기타</span></a></li>
+      </ul>
+    </nav>
+  </div>
+  <div class="policy-detail-page">
+    <div class="policy-header">
+      <sec:authorize access="isAuthenticated()">
+        <div class="icon">
+          <label class="container">
+            <input type="checkbox"
+                   id="scrapCheck"
+                <c:if test="${not empty scrapInfo}">
+                  <c:forEach items="${scrapInfo}" var="scrap">
+                    <c:if test="${scrap.policyCode == policyDetails.policyCode}">
+                      checked
+                    </c:if>
+                  </c:forEach>
+                </c:if>
+            />
+            <div class="check" data-policy-code="${policyDetails.policyCode}"
+                <c:if test="${not empty scrapInfo}">
+                  <c:forEach items="${scrapInfo}" var="scrap">
+                    <c:if test="${scrap.policyCode == policyDetails.policyCode}">
+                      data-scrap-id="${scrap.scrapId}"
+                    </c:if>
+                  </c:forEach>
+                </c:if>
+            >
+              <svg viewBox="0 0 256 256">
+                <rect fill="none" height="256" width="256"></rect>
+                <path
+                    d="M224.6,51.9a59.5,59.5,0,0,0-43-19.9,60.5,60.5,0,0,0-44,17.6L128,59.1l-7.5-7.4C97.2,28.3,59.2,26.3,35.9,47.4a59.9,59.9,0,0,0-2.3,87l83.1,83.1a15.9,15.9,0,0,0,22.6,0l81-81C243.7,113.2,245.6,75.2,224.6,51.9Z"
+                    stroke-width="20px"
+                    stroke="#000"
+                    fill="none"
+                ></path>
+              </svg>
+            </div>
+          </label>
+        </div>
+      </sec:authorize>
+      <div class="policy-title">
+        <h2>${policyDetails.policyName !="null" && policyDetails.policyName !=null && !policyDetails.policyName.isEmpty()? policyDetails.policyName:"❌"}</h2>
+        <h3>${policyDetails.policyContent !="null" && policyDetails.policyContent !=null && !policyDetails.policyContent.isEmpty()? policyDetails.policyContent:"❌"}</h3>
+      </div>
+      <div class="button-link">
+      </div>
     </div>
-    <div class="policy-detail-page">
-        <div class="policy-header">
-            <sec:authorize access="isAuthenticated()">
-                <div class="icon">
-                    <label class="container">
-                        <input type="checkbox"
-                               id="scrapCheck"
-                                <c:if test="${not empty scrapInfo}">
-                                    <c:forEach items="${scrapInfo}" var="scrap">
-                                        <c:if test="${scrap.policyCode == policyDetails.policyCode}">
-                                            checked
-                                        </c:if>
-                                    </c:forEach>
-                                </c:if>
-                        />
-                        <div class="check" data-policy-code="${policyDetails.policyCode}"
-                                <c:if test="${not empty scrapInfo}">
-                                    <c:forEach items="${scrapInfo}" var="scrap">
-                                        <c:if test="${scrap.policyCode == policyDetails.policyCode}">
-                                            data-scrap-id="${scrap.scrapId}"
-                                        </c:if>
-                                    </c:forEach>
-                                </c:if>
-                        >
-                            <svg viewBox="0 0 256 256">
-                                <rect fill="none" height="256" width="256"></rect>
-                                <path
-                                        d="M224.6,51.9a59.5,59.5,0,0,0-43-19.9,60.5,60.5,0,0,0-44,17.6L128,59.1l-7.5-7.4C97.2,28.3,59.2,26.3,35.9,47.4a59.9,59.9,0,0,0-2.3,87l83.1,83.1a15.9,15.9,0,0,0,22.6,0l81-81C243.7,113.2,245.6,75.2,224.6,51.9Z"
-                                        stroke-width="20px"
-                                        stroke="#000"
-                                        fill="none"
-                                ></path>
-                            </svg>
-                        </div>
-                    </label>
-                </div>
-            </sec:authorize>
-            <div class="policy-title">
-                <h2>${policyDetails.policyName !="null" && policyDetails.policyName !=null && !policyDetails.policyName.isEmpty()? policyDetails.policyName:"❌"}</h2>
-                <h3>${policyDetails.policyContent !="null" && policyDetails.policyContent !=null && !policyDetails.policyContent.isEmpty()? policyDetails.policyContent:"❌"}</h3>
+
+    <div class="policy-table-content" id="section1">
+      <div class="policy-table-header">
+        <h3>한 눈에 보는 정책 요약</h3>
+      </div>
+      <ul>
+        <li>
+          <div class="list-container">
+            <div class="list-title">정책 번호</div>
+            <div
+                class="list-content">${policyDetails.policyCode !="null" && policyDetails.policyCode !=null && !policyDetails.policyCode.isEmpty()? policyDetails.policyCode:"❌"}</div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">정책 분야</div>
+            <div
+                class="list-content">${policyDetails.categoryCode !="null" && policyDetails.categoryCode !=null && !policyDetails.categoryCode.isEmpty()? policyDetails.categoryCode:"❌"}</div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">사업 운영 기간</div>
+            <div
+                class="list-content">${policyDetails.prdRpttSecd !="null" && policyDetails.prdRpttSecd !=null && !policyDetails.prdRpttSecd.isEmpty()? policyDetails.prdRpttSecd:"❌"}</div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">사업 신청 기간</div>
+            <div
+                class="list-content">${policyDetails.schedule !="null" && policyDetails.schedule !=null && !policyDetails.schedule.isEmpty()? policyDetails.schedule:"❌"}</div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">지원 규모</div>
+            <div class="list-content">something here sometimes</div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">지원 내용</div>
+            <div class="list-content">
+              ${policyDetails.supportContent !="null" && policyDetails.supportContent !=null && !policyDetails.supportContent.isEmpty()? policyDetails.supportContent:"❌"}
             </div>
-            <div class="button-link">
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">비고</div>
+            <div class="list-content">
+              something something
             </div>
-        </div>
+          </div>
+        </li>
 
-        <div class="policy-table-content" id="section1">
-            <div class="policy-table-header">
-                <h3>한 눈에 보는 정책 요약</h3>
-            </div>
-            <ul>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">정책 번호</div>
-                        <div class="list-content">${policyDetails.policyCode !="null" && policyDetails.policyCode !=null && !policyDetails.policyCode.isEmpty()? policyDetails.policyCode:"❌"}</div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">정책 분야</div>
-                        <div class="list-content">${policyDetails.categoryCode !="null" && policyDetails.categoryCode !=null && !policyDetails.categoryCode.isEmpty()? policyDetails.categoryCode:"❌"}</div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">사업 운영 기간</div>
-                        <div class="list-content">${policyDetails.prdRpttSecd !="null" && policyDetails.prdRpttSecd !=null && !policyDetails.prdRpttSecd.isEmpty()? policyDetails.prdRpttSecd:"❌"}</div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">사업 신청 기간</div>
-                        <div class="list-content">${policyDetails.schedule !="null" && policyDetails.schedule !=null && !policyDetails.schedule.isEmpty()? policyDetails.schedule:"❌"}</div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">지원 규모</div>
-                        <div class="list-content">something here sometimes</div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">지원 내용</div>
-                        <div class="list-content">
-                            ${policyDetails.supportContent !="null" && policyDetails.supportContent !=null && !policyDetails.supportContent.isEmpty()? policyDetails.supportContent:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">비고</div>
-                        <div class="list-content">
-                            something something
-                        </div>
-                    </div>
-                </li>
-
-            </ul>
-        </div>
-
-        <div class="policy-table-content" id="section2">
-            <div class="policy-table-header">
-                <h3>신청자격</h3>
-            </div>
-            <ul>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">연령</div>
-                        <div class="list-content">${policyDetails.ageInfo !="null" && policyDetails.ageInfo !=null && !policyDetails.ageInfo.isEmpty()? policyDetails.ageInfo:"❌"}</div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">취업 상태</div>
-                        <div class="list-content">
-                            ${policyDetails.empmSttsCn !="null" && policyDetails.empmSttsCn !=null && !policyDetails.empmSttsCn.isEmpty()? policyDetails.empmSttsCn:"❌"}
-                        </div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">학력</div>
-                        <div class="list-content">
-                            ${policyDetails.accrRqisCn!="null" && policyDetails.accrRqisCn!=null && !policyDetails.accrRqisCn.isEmpty()? policyDetails.accrRqisCn:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">전공</div>
-                        <div class="list-content">
-                            ${policyDetails.majorRqisCn!="null" && policyDetails.majorRqisCn!=null && !policyDetails.majorRqisCn.isEmpty()? policyDetails.majorRqisCn:"❌"}
-                        </div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">특화 분야</div>
-                        <div class="list-content">
-                            ${policyDetails.splzRlmRqisCn !="null" && policyDetails.splzRlmRqisCn !=null &&!policyDetails.splzRlmRqisCn.isEmpty()? policyDetails.splzRlmRqisCn:"❌"}
-                        </div>
-                    </div>
-
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">거주지 및 소득</div>
-                        <div class="list-content">
-                            ${policyDetails.prcpCn !="null" && policyDetails.prcpCn !=null && !policyDetails.prcpCn.isEmpty()? policyDetails.prcpCn:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">참여 제한 대상</div>
-                        <div class="list-content">
-                            ${policyDetails.prcpLmttTrgtCn !="null" && policyDetails.prcpLmttTrgtCn !=null && !policyDetails.prcpLmttTrgtCn.isEmpty()? policyDetails.prcpLmttTrgtCn:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">추가 단서 사항</div>
-                        <div class="list-content">
-                            ${policyDetails.aditRscn !="null" && policyDetails.aditRscn !=null && !policyDetails.aditRscn.isEmpty()? policyDetails.aditRscn:"❌"}
-
-                        </div>
-                    </div>
-                </li>
-
-
-            </ul>
-        </div>
-
-        <div class="policy-table-content" id="section3">
-            <div class="policy-table-header">
-                <h3>신청방법</h3>
-            </div>
-            <ul>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">신청 절차</div>
-                        <div class="list-content">
-                            ${policyDetails.rqutProcCn !="null" && policyDetails.rqutProcCn !=null && !policyDetails.rqutProcCn.isEmpty()? policyDetails.rqutProcCn:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">심사 및 발표</div>
-                        <div class="list-content">
-                            ${policyDetails.jdgnPresCn !="null" && policyDetails.jdgnPresCn !=null && !policyDetails.jdgnPresCn.isEmpty()? policyDetails.jdgnPresCn:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">신청 사이트</div>
-                        <div class="list-content">
-                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-                            <c:if test="${policyDetails.rqutUrla != 'null' && policyDetails.rqutUrla != null && !policyDetails.rqutUrla.isEmpty()}">
-                                <a href="${policyDetails.rqutUrla}">${policyDetails.rqutUrla}</a>
-                            </c:if>
-
-                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-                            <c:if test="${policyDetails.rqutUrla == 'null' || policyDetails.rqutUrla == null || policyDetails.rqutUrla.isEmpty()}">
-                                ❌
-                            </c:if>
-
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">제출 서류</div>
-                        <div class="list-content">
-                            ${policyDetails.pstnPaprCn !="null" && policyDetails.pstnPaprCn !=null && !policyDetails.pstnPaprCn.isEmpty()? policyDetails.pstnPaprCn:"❌"}
-                        </div>
-                    </div>
-            </ul>
-        </div>
-        <div class="policy-table-content" id="section4">
-            <div class="policy-table-header">
-                <h3>기타</h3>
-            </div>
-            <ul>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">기타 유익 정보</div>
-                        <div class="list-content">
-                            ${policyDetails.etct !="null" && policyDetails.etct !=null && !policyDetails.etct.isEmpty()? policyDetails.etct:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">주관 기관</div>
-                        <div class="list-content">
-                            ${policyDetails.mngtMson !="null" && policyDetails.mngtMson !=null && !policyDetails.mngtMson.isEmpty()? policyDetails.mngtMson:"❌"}
-                        </div>
-                    </div>
-                    <div class="list-container">
-                        <div class="list-title">운영 기관</div>
-                        <div class="list-content">
-                            ${policyDetails.cnsgNmor !="null" && policyDetails.cnsgNmor !=null && !policyDetails.cnsgNmor.isEmpty()? policyDetails.cnsgNmor:"❌"}
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">사업관련 참고 사이트1</div>
-                        <div class="list-content">
-                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-                            <c:if test="${policyDetails.rfcSiteUrla1 != 'null' && policyDetails.rfcSiteUrla1 != null && !policyDetails.rfcSiteUrla1.isEmpty()}">
-                                <a href="${policyDetails.rfcSiteUrla1}">${policyDetails.rfcSiteUrla1}</a>
-                            </c:if>
-
-                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-                            <c:if test="${policyDetails.rfcSiteUrla1 == 'null' || policyDetails.rfcSiteUrla1 == null || policyDetails.rfcSiteUrla1.isEmpty()}">
-                                ❌
-                            </c:if>
-
-                        </div>
-                    </div>
-                </li>
-                <li>
-                    <div class="list-container">
-                        <div class="list-title">사업관련 참고 사이트2</div>
-                        <div class="list-content">
-
-                            <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
-                            <c:if test="${policyDetails.rfcSiteUrla2 != 'null' && policyDetails.rfcSiteUrla2 != null && !policyDetails.rfcSiteUrla2.isEmpty()}">
-                                <a href="${policyDetails.rfcSiteUrla2}">${policyDetails.rfcSiteUrla2}</a>
-                            </c:if>
-
-                            <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
-                            <c:if test="${policyDetails.rfcSiteUrla2 == 'null' || policyDetails.rfcSiteUrla2 == null ||policyDetails.rfcSiteUrla2.isEmpty()}">
-                                ❌
-                            </c:if>
-                        </div>
-                    </div>
-                </li>
-            </ul>
-        </div>
-        <div class="top-areas">
-            <h2>지금 보고 있는 혜택 이용자 평점</h2>
-            <div class="avg-score" id="avg-score"
-                 data-score="${policyDetails.avgPolicyScore}">${policyDetails.avgPolicyScore}</div>
-            <div class="rating">
-                <input type="radio" id="star5" name="rating" value="5" disabled>
-                <label for="star5"
-                       class="${policyDetails.avgPolicyScore >= 5 ? 'filled' : ''}"></label>
-                <input type="radio" id="star4" name="rating" value="4" disabled>
-                <label for="star4"
-                       class="${policyDetails.avgPolicyScore >= 4 ? 'filled' : ''}"></label>
-                <input type="radio" id="star3" name="rating" value="3" disabled>
-                <label for="star3"
-                       class="${policyDetails.avgPolicyScore >= 3 ? 'filled' : ''}"></label>
-                <input type="radio" id="star2" name="rating" value="2" disabled>
-                <label for="star2"
-                       class="${policyDetails.avgPolicyScore >= 2 ? 'filled' : ''}"></label>
-                <input type="radio" id="star1" name="rating" value="1" disabled>
-                <label for="star1"
-                       class="${policyDetails.avgPolicyScore >= 1 ? 'filled' : ''}"></label>
-            </div>
-        </div>
-        <div class="top-areas">
-            <h2>지금 보고 있는 혜택과 비슷한 혜택</h2>
-            <%-- 같은 카테고리인 정책 랜덤 추천--%>
-            <div class="areas-list">
-                <div class="area-item"
-                     onclick="goToPolicy('${firstPolicyRecommendation.policyCode}')">
-                    <div class="area-container">
-                        <img src="${pageContext.request.contextPath}${district1.districtLogoPath}"
-                             alt="${district1.districtName}"/>
-                    </div>
-                    <div class="text">
-                        <p class="region-name">${firstPolicyRecommendation.policyName}</p>
-                        <p class="region-tag">${firstPolicyRecommendation.policyContent}</p>
-                    </div>
-                </div>
-                <div class="area-item"
-                     onclick="goToPolicy('${secondPolicyRecommendation.policyCode}')">
-                    <div class="area-container">
-                        <img src="${pageContext.request.contextPath}${district2.districtLogoPath}"
-                             alt="${district2.districtName}"/>
-                    </div>
-                    <div class="text">
-                        <p class="region-name">${secondPolicyRecommendation.policyName}</p>
-                        <p class="region-tag">${secondPolicyRecommendation.policyContent}</p>
-                    </div>
-                </div>
-                <div class="area-item"
-                     onclick="goToPolicy('${thirdPolicyRecommendation.policyCode}')">
-                    <div class="area-container">
-                        <img src="${pageContext.request.contextPath}${district3.districtLogoPath}"
-                             alt="${district3.districtName}"/>
-                    </div>
-                    <div class="text">
-                        <p class="region-name">${thirdPolicyRecommendation.policyName}</p>
-                        <p class="region-tag">${thirdPolicyRecommendation.policyContent}</p>
-                    </div>
-                </div>
-
-            </div>
-        </div>
+      </ul>
     </div>
+
+    <div class="policy-table-content" id="section2">
+      <div class="policy-table-header">
+        <h3>신청자격</h3>
+      </div>
+      <ul>
+        <li>
+          <div class="list-container">
+            <div class="list-title">연령</div>
+            <div
+                class="list-content">${policyDetails.ageInfo !="null" && policyDetails.ageInfo !=null && !policyDetails.ageInfo.isEmpty()? policyDetails.ageInfo:"❌"}</div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">취업 상태</div>
+            <div class="list-content">
+              ${policyDetails.empmSttsCn !="null" && policyDetails.empmSttsCn !=null && !policyDetails.empmSttsCn.isEmpty()? policyDetails.empmSttsCn:"❌"}
+            </div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">학력</div>
+            <div class="list-content">
+              ${policyDetails.accrRqisCn!="null" && policyDetails.accrRqisCn!=null && !policyDetails.accrRqisCn.isEmpty()? policyDetails.accrRqisCn:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">전공</div>
+            <div class="list-content">
+              ${policyDetails.majorRqisCn!="null" && policyDetails.majorRqisCn!=null && !policyDetails.majorRqisCn.isEmpty()? policyDetails.majorRqisCn:"❌"}
+            </div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">특화 분야</div>
+            <div class="list-content">
+              ${policyDetails.splzRlmRqisCn !="null" && policyDetails.splzRlmRqisCn !=null &&!policyDetails.splzRlmRqisCn.isEmpty()? policyDetails.splzRlmRqisCn:"❌"}
+            </div>
+          </div>
+
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">거주지 및 소득</div>
+            <div class="list-content">
+              ${policyDetails.prcpCn !="null" && policyDetails.prcpCn !=null && !policyDetails.prcpCn.isEmpty()? policyDetails.prcpCn:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">참여 제한 대상</div>
+            <div class="list-content">
+              ${policyDetails.prcpLmttTrgtCn !="null" && policyDetails.prcpLmttTrgtCn !=null && !policyDetails.prcpLmttTrgtCn.isEmpty()? policyDetails.prcpLmttTrgtCn:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">추가 단서 사항</div>
+            <div class="list-content">
+              ${policyDetails.aditRscn !="null" && policyDetails.aditRscn !=null && !policyDetails.aditRscn.isEmpty()? policyDetails.aditRscn:"❌"}
+
+            </div>
+          </div>
+        </li>
+
+
+      </ul>
+    </div>
+
+    <div class="policy-table-content" id="section3">
+      <div class="policy-table-header">
+        <h3>신청방법</h3>
+      </div>
+      <ul>
+        <li>
+          <div class="list-container">
+            <div class="list-title">신청 절차</div>
+            <div class="list-content">
+              ${policyDetails.rqutProcCn !="null" && policyDetails.rqutProcCn !=null && !policyDetails.rqutProcCn.isEmpty()? policyDetails.rqutProcCn:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">심사 및 발표</div>
+            <div class="list-content">
+              ${policyDetails.jdgnPresCn !="null" && policyDetails.jdgnPresCn !=null && !policyDetails.jdgnPresCn.isEmpty()? policyDetails.jdgnPresCn:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">신청 사이트</div>
+            <div class="list-content">
+              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+              <c:if
+                  test="${policyDetails.rqutUrla != 'null' && policyDetails.rqutUrla != null && !policyDetails.rqutUrla.isEmpty()}">
+                <a href="${policyDetails.rqutUrla}">${policyDetails.rqutUrla}</a>
+              </c:if>
+
+              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+              <c:if
+                  test="${policyDetails.rqutUrla == 'null' || policyDetails.rqutUrla == null || policyDetails.rqutUrla.isEmpty()}">
+                ❌
+              </c:if>
+
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">제출 서류</div>
+            <div class="list-content">
+              ${policyDetails.pstnPaprCn !="null" && policyDetails.pstnPaprCn !=null && !policyDetails.pstnPaprCn.isEmpty()? policyDetails.pstnPaprCn:"❌"}
+            </div>
+          </div>
+      </ul>
+    </div>
+    <div class="policy-table-content" id="section4">
+      <div class="policy-table-header">
+        <h3>기타</h3>
+      </div>
+      <ul>
+        <li>
+          <div class="list-container">
+            <div class="list-title">기타 유익 정보</div>
+            <div class="list-content">
+              ${policyDetails.etct !="null" && policyDetails.etct !=null && !policyDetails.etct.isEmpty()? policyDetails.etct:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">주관 기관</div>
+            <div class="list-content">
+              ${policyDetails.mngtMson !="null" && policyDetails.mngtMson !=null && !policyDetails.mngtMson.isEmpty()? policyDetails.mngtMson:"❌"}
+            </div>
+          </div>
+          <div class="list-container">
+            <div class="list-title">운영 기관</div>
+            <div class="list-content">
+              ${policyDetails.cnsgNmor !="null" && policyDetails.cnsgNmor !=null && !policyDetails.cnsgNmor.isEmpty()? policyDetails.cnsgNmor:"❌"}
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">사업관련 참고 사이트1</div>
+            <div class="list-content">
+              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+              <c:if
+                  test="${policyDetails.rfcSiteUrla1 != 'null' && policyDetails.rfcSiteUrla1 != null && !policyDetails.rfcSiteUrla1.isEmpty()}">
+                <a href="${policyDetails.rfcSiteUrla1}">${policyDetails.rfcSiteUrla1}</a>
+              </c:if>
+
+              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+              <c:if
+                  test="${policyDetails.rfcSiteUrla1 == 'null' || policyDetails.rfcSiteUrla1 == null || policyDetails.rfcSiteUrla1.isEmpty()}">
+                ❌
+              </c:if>
+
+            </div>
+          </div>
+        </li>
+        <li>
+          <div class="list-container">
+            <div class="list-title">사업관련 참고 사이트2</div>
+            <div class="list-content">
+
+              <!-- rqutUrla가 null이 아니고 빈 문자열이 아닌 경우에만 링크를 출력 -->
+              <c:if
+                  test="${policyDetails.rfcSiteUrla2 != 'null' && policyDetails.rfcSiteUrla2 != null && !policyDetails.rfcSiteUrla2.isEmpty()}">
+                <a href="${policyDetails.rfcSiteUrla2}">${policyDetails.rfcSiteUrla2}</a>
+              </c:if>
+
+              <!-- rqutUrla가 null이거나 빈 문자열이면 "❌" 표시 -->
+              <c:if
+                  test="${policyDetails.rfcSiteUrla2 == 'null' || policyDetails.rfcSiteUrla2 == null ||policyDetails.rfcSiteUrla2.isEmpty()}">
+                ❌
+              </c:if>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div class="top-areas">
+      <h2>지금 보고 있는 혜택 이용자 평점</h2>
+      <div class="avg-score" id="avg-score"
+           data-score="${policyDetails.avgPolicyScore}">${policyDetails.avgPolicyScore}</div>
+      <div class="rating">
+        <input type="radio" id="star5" name="rating" value="5" disabled>
+        <label for="star5"
+               class="${policyDetails.avgPolicyScore >= 5 ? 'filled' : ''}"></label>
+        <input type="radio" id="star4" name="rating" value="4" disabled>
+        <label for="star4"
+               class="${policyDetails.avgPolicyScore >= 4 ? 'filled' : ''}"></label>
+        <input type="radio" id="star3" name="rating" value="3" disabled>
+        <label for="star3"
+               class="${policyDetails.avgPolicyScore >= 3 ? 'filled' : ''}"></label>
+        <input type="radio" id="star2" name="rating" value="2" disabled>
+        <label for="star2"
+               class="${policyDetails.avgPolicyScore >= 2 ? 'filled' : ''}"></label>
+        <input type="radio" id="star1" name="rating" value="1" disabled>
+        <label for="star1"
+               class="${policyDetails.avgPolicyScore >= 1 ? 'filled' : ''}"></label>
+      </div>
+    </div>
+    <div class="top-areas">
+      <h2>지금 보고 있는 혜택과 비슷한 혜택</h2>
+      <%-- 같은 카테고리인 정책 랜덤 추천--%>
+      <div class="areas-list">
+        <div class="area-item"
+             onclick="goToPolicy('${firstPolicyRecommendation.policyCode}')">
+          <div class="area-container">
+            <img src="${pageContext.request.contextPath}${firstPolicyDistrict.districtLogoPath}"
+                 alt="${firstPolicyDistrict.districtName}"/>
+          </div>
+          <div class="text">
+            <p class="region-name">${firstPolicyRecommendation.policyName}</p>
+            <p class="region-tag">${firstPolicyRecommendation.policyContent}</p>
+          </div>
+        </div>
+        <div class="area-item"
+             onclick="goToPolicy('${secondPolicyRecommendation.policyCode}')">
+          <div class="area-container">
+            <img src="${pageContext.request.contextPath}${secondPolicyDistrict.districtLogoPath}"
+                 alt="${secondPolicyDistrict.districtName}"/>
+          </div>
+          <div class="text">
+            <p class="region-name">${secondPolicyRecommendation.policyName}</p>
+            <p class="region-tag">${secondPolicyRecommendation.policyContent}</p>
+          </div>
+        </div>
+        <div class="area-item"
+             onclick="goToPolicy('${thirdPolicyRecommendation.policyCode}')">
+          <div class="area-container">
+            <img src="${pageContext.request.contextPath}${thirdPolicyDistrict.districtLogoPath}"
+                 alt="${thirdPolicyDistrict.districtName}"/>
+          </div>
+          <div class="text">
+            <p class="region-name">${thirdPolicyRecommendation.policyName}</p>
+            <p class="region-tag">${thirdPolicyRecommendation.policyContent}</p>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
 </div>
 
 <jsp:include page="${pageContext.request.contextPath}/WEB-INF/components/footer.jsp"/>

--- a/src/main/webapp/css/policy/detail.css
+++ b/src/main/webapp/css/policy/detail.css
@@ -255,10 +255,11 @@ body {
   gap: 30px; /* 이미지와 텍스트 사이의 간격 */
   box-sizing: border-box; /* 테두리와 패딩을 너비에 포함 */
   overflow: hidden; /* 내용이 요소를 벗어나지 않도록 설정 */
+  width: 100%;
 }
 
 .area-item img {
-  width: 150px; /* 고정 폭 */
+  width: 100px; /* 고정 폭 */
   height: auto;
   max-height: 150px; /* 이미지 크기 조정 */
 }
@@ -330,6 +331,9 @@ body {
     font-size: 15px;
   }
 
+  .region-tag{
+    display: none;
+  }
 }
 
 /* 하트 아이콘 css */


### PR DESCRIPTION
## #️⃣ Relationship Issues
- #66 

<br>

## 💡 Key Changes
### 1. 정책 추천기능 연동
- 정책의 점수가 아닌 같은 카테고리(ex. 일자리, 주거)에 해당하는 정책 3개를 추천합니다.
- 화면에 데이터 값 출력
- 클릭 하여 다른 페이지 이동 기능

<img width="909" alt="image" src="https://github.com/user-attachments/assets/099c853d-9769-4cd5-a5f4-305028025fe2">

### 2. 컨텐츠 내용이 "null" String 또는 null 값 모두 ❌ 표시 되도록 변경하였습니다.

<br>

## ➕ ETC 
- controller에 데이터 호출한 부분에 있어서 refactoring이 필요한지 확인 부탁드립니다.
